### PR TITLE
use many2many_tags for m2m widget; fixes #2

### DIFF
--- a/base_custom_attribute/models/attribute_attribute.py
+++ b/base_custom_attribute/models/attribute_attribute.py
@@ -49,6 +49,11 @@ class AttributeAttribute(models.Model):
                 colspan="4",
             )
             kwargs["nolabel"] = "1"
+            if attribute.ttype == "many2many":
+                # TODO use an attribute field instead
+                # to let user specify the widget. For now it fixes:
+                # https://github.com/shopinvader/odoo-pim/issues/2
+                kwargs["widget"] = "many2many_tags"
 
         if attribute.ttype in ["many2one", "many2many"]:
             if attribute.relation_model_id:


### PR DESCRIPTION
fixes https://github.com/OCA/sale-workflow/pull/516

It looks like this now:

![Screenshot from 2019-05-22 10-17-49](https://user-images.githubusercontent.com/16926/58177505-e3ba4300-7c7a-11e9-8381-b5e0642182b2.png)

In the future we could have a specific field to specify the attribute widget. But as for now, as only the many2many_tags widget works for m2m I suggest to force it by default.
