### PR TITLE
attrs on product template and force_model->default_model_id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 
 addons:
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility

--- a/base_custom_attribute/models/attribute_set.py
+++ b/base_custom_attribute/models/attribute_set.py
@@ -5,7 +5,7 @@
 # Copyright 2015 Savoir-faire Linux
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class AttributeSet(models.Model):
@@ -18,18 +18,4 @@ class AttributeSet(models.Model):
         "attribute.group", "attribute_set_id", "Attribute Groups"
     )
 
-    @api.model
-    def _get_default_model(self):
-        force_model = self.env.context.get("force_model")
-
-        if force_model:
-            models = self.env["ir.model"].search([("model", "=", force_model)])
-
-            if models:
-                return models[0]
-
-        return False
-
-    model_id = fields.Many2one(
-        "ir.model", "Model", required=True, default=_get_default_model
-    )
+    model_id = fields.Many2one("ir.model", "Model", required=True)

--- a/base_custom_attribute/views/attribute_set_view.xml
+++ b/base_custom_attribute/views/attribute_set_view.xml
@@ -9,9 +9,9 @@
                 <form string="Attribute Set">
                     <group>
                         <field name="name"/>
-                        <field name="model_id" invisible="context.get('force_model')"/>
+                        <field name="model_id" invisible="context.get('default_model_id')"/>
                         <field name="attribute_group_ids" colspan="4"
-                               context="{'default_model_id': model_id, 'from_attribute_set':True}">
+                               context="{'default_model_id': model_id}">
                         </field>
                     </group>
                 </form>

--- a/product_custom_attribute/views/attribute_attribute.xml
+++ b/product_custom_attribute/views/attribute_attribute.xml
@@ -8,7 +8,7 @@
       <field name="view_type">form</field>
       <field name="view_mode">tree,form</field>
       <field name="search_view_id" ref="base_custom_attribute.view_attribute_attribute_search"/>
-      <field name="context">{"force_model": 'product.product'}</field>
+      <field name="context">{'default_model_id': %(product.model_product_template)d}</field>
       <field name="help"></field>
     </record>
 

--- a/product_custom_attribute/views/attribute_group.xml
+++ b/product_custom_attribute/views/attribute_group.xml
@@ -8,7 +8,7 @@
       <field name="view_type">form</field>
       <field name="view_mode">tree,form</field>
       <field name="search_view_id" ref="base_custom_attribute.view_attribute_attribute_search"/>
-      <field name="context">{"force_model": 'product.product'}</field>
+      <field name="context">{'default_model_id': %(product.model_product_template)d}</field>
       <field name="help"></field>
     </record>
 

--- a/product_custom_attribute/views/attribute_set.xml
+++ b/product_custom_attribute/views/attribute_set.xml
@@ -14,7 +14,7 @@
       <field name="view_type">form</field>
       <field name="view_mode">tree,form</field>
       <field name="search_view_id" ref="base_custom_attribute.view_attribute_set_search"/>
-      <field name="context">{"force_model": 'product.product'}</field>
+      <field name="context" eval="{'default_model_id': ref('product.model_product_template')}"/>
       <field name="help"></field>
     </record>
 

--- a/product_custom_attribute/views/product.xml
+++ b/product_custom_attribute/views/product.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="product.product_template_form_view" />
             <field name="arch" type="xml">
                 <field name="type" position="after">
-                    <field name="attribute_set_id"/>
+                    <field name="attribute_set_id" context="{'default_model_id': %(product.model_product_template)d}"/>
                 </field>
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="open_attributes"


### PR DESCRIPTION
1) In general use the Odoo built'in system for specifying the default model using the `default_` prefix with `default_model_id` and get rid of the `force_model` key and the default_get custom override.

2) the `from_attribute_set` key was used nowwhere so we deleted it.

3) As discussed with @sebastienbeau, we may want custom attributes both for templates and variants. However the existing code was broken: the `Open Attributes` button was only for the product template, a large part of the code was designed for product template attributes but at some place the specified model was `product.product` and mixing both without care would crash Odoo in a very bad way were your database is broken until somebody eventually clean it. So I unified the models to `product.template` instead and ensured it works. I suggest that if somebody wants attributes on product variants, he creates an extra module that would provide the appropriate buttons and menus but the way it was was simply broken...
