### PR TITLE
[FIX] attribute_set_completeness: speed up completion fields

### DIFF
--- a/attribute_set_completeness/__init__.py
+++ b/attribute_set_completeness/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
+from . import components
 from . import models

--- a/attribute_set_completeness/__manifest__.py
+++ b/attribute_set_completeness/__manifest__.py
@@ -8,7 +8,7 @@
     "license": "AGPL-3",
     "author": "ACSONE SA/NV",
     "website": "https://acsone.eu",
-    "depends": ["attribute_set"],
+    "depends": ["attribute_set", "component_event"],
     "data": [
         "views/attribute_set.xml",
         "security/attribute_set_completeness.xml",

--- a/attribute_set_completeness/components/__init__.py
+++ b/attribute_set_completeness/components/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import attribute_set_owner_event_listener

--- a/attribute_set_completeness/components/attribute_set_owner_event_listener.py
+++ b/attribute_set_completeness/components/attribute_set_owner_event_listener.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.addons.component.core import AbstractComponent
+from odoo.addons.component_event import skip_if
+
+
+class AttributeSetOwnerEventListener(AbstractComponent):
+    _name = "attribute.set.owner.event.listener"
+    _inherit = "base.event.listener"
+
+    def _get_skip_if_condition(self, record, **kwargs):
+        if not record.attribute_set_id:
+            return True
+        fields = kwargs["fields"]
+        if "attribute_set_id" in fields or any(
+            [
+                field
+                for field in fields
+                if field
+                in record.attribute_set_id.attribute_set_completeness_ids.mapped(
+                    "field_id.name"
+                )
+            ]
+        ):
+            return False
+
+        return True
+
+    @skip_if(
+        lambda self, record, **kwargs: self._get_skip_if_condition(record, **kwargs)
+    )
+    def on_record_write(self, record, fields=None):
+        record._compute_completion_rate()

--- a/attribute_set_completeness/models/attribute_set_owner_mixin.py
+++ b/attribute_set_completeness/models/attribute_set_owner_mixin.py
@@ -3,24 +3,23 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-from odoo.osv import expression
 
 
 class AttributeSetOwnerMixin(models.AbstractModel):
 
     _inherit = "attribute.set.owner.mixin"
 
-    completion_rate = fields.Float(compute="_compute_completion_rate", readonly=True)
+    completion_rate = fields.Float(default=0.0, readonly=True)
     completion_state = fields.Selection(
         selection=[("complete", "Complete"), ("not_complete", "Not complete")],
-        compute="_compute_completion_rate",
-        search="_search_complete_state",
+        default="not_complete",
+        readonly=True,
     )
     attribute_set_completeneness_ids = fields.One2many(
         related="attribute_set_id.attribute_set_completeness_ids", readonly=True,
     )
     attribute_set_not_completed_ids = fields.Many2many(
-        comodel_name="attribute.set.completeness", compute="_compute_completion_rate",
+        comodel_name="attribute.set.completeness", readonly=True
     )
 
     @api.multi
@@ -30,53 +29,19 @@ class AttributeSetOwnerMixin(models.AbstractModel):
             completion_config = attribute_set_id.attribute_set_completeness_ids
             if completion_config:
                 completion_rate = 0.0
+                not_complete_crit = self.env["attribute.set.completeness"].browse()
                 for criteria in completion_config:
                     field_name = criteria.field_id.name
                     if record[field_name]:
                         completion_rate += criteria.completion_rate
                     else:
-                        record.attribute_set_not_completed_ids |= criteria
+                        not_complete_crit |= criteria
                 record.completion_rate = completion_rate
+                record.attribute_set_not_completed_ids = not_complete_crit
                 if completion_rate < 100:
                     record.completion_state = "not_complete"
                 else:
                     record.completion_state = "complete"
             else:
-                record.completion_rate = False
-                record.completion_state = False
-
-    @api.multi
-    def _search_complete_state(self, operator, value):
-
-        negative = operator in expression.NEGATIVE_TERM_OPERATORS
-        default_res = expression.TRUE_DOMAIN if negative else expression.FALSE_DOMAIN
-
-        # In case we have no value
-        if not value:
-            return default_res
-
-        if operator in ["in", "not in"]:
-            if len(value) > 1:
-                return default_res
-            value = value[0]
-            operator = "!=" if negative else "="
-
-        if operator in ["=", "!="]:
-            if value not in ["complete", "not_complete"]:
-                return default_res
-            if (operator == "=" and value == "complete") or (
-                operator == "!=" and value == "not_complete"
-            ):
-                products = self.search([("attribute_set_id", "!=", False)])
-                products = products.filtered(lambda x: x.completion_state == "complete")
-            else:
-                products = self.search([("attribute_set_id", "!=", False)])
-                products = products.filtered(
-                    lambda x: x.completion_state == "not_complete"
-                )
-                prod_no_set = self.search([("attribute_set_id", "=", False)])
-                products |= prod_no_set
-
-            return [("id", "in", products.ids)]
-
-        return default_res
+                record.completion_rate = 0
+                record.completion_state = "not_complete"

--- a/attribute_set_completeness/tests/res_partner_event_listener.py
+++ b/attribute_set_completeness/tests/res_partner_event_listener.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.addons.component.core import Component
+
+
+class ResPartnerEventListener(Component):
+    _name = "res.partner.event.listener"
+    _inherit = ["attribute.set.owner.event.listener"]
+
+    _apply_on = ["res.partner"]

--- a/attribute_set_completeness/tests/test_attribute_set_completeness.py
+++ b/attribute_set_completeness/tests/test_attribute_set_completeness.py
@@ -45,7 +45,11 @@ class TestAttributeSetCompleteness(SavepointCase):
         cls.loader = FakeModelLoader(cls.env, cls.__module__)
         cls.loader.backup_registry()
         from odoo.addons.attribute_set.tests.models import ResPartner
+        from .res_partner_event_listener import ResPartnerEventListener  # noqa: F401
 
+        cls.component_builder = cls.env["component.builder"]
+        cls.component_builder._register_hook()
+        cls.component_builder.load_components("attribute_set_completeness")
         cls.loader.update_registry((ResPartner,))
 
     @classmethod
@@ -93,8 +97,8 @@ class TestAttributeSetCompleteness(SavepointCase):
     def test_completion_rate(self):
         vals = {"name": "Test Partner"}
         partner = self.env["res.partner"].create(vals)
-        self.assertFalse(partner.completion_state)
-        self.assertFalse(partner.completion_rate)
+        self.assertEqual(partner.completion_state, "not_complete")
+        self.assertEqual(partner.completion_rate, 0.0)
 
         partner.write({"attribute_set_id": self.attr_set.id})
         partner.invalidate_cache()

--- a/product_attribute_set_completeness/__init__.py
+++ b/product_attribute_set_completeness/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import components

--- a/product_attribute_set_completeness/components/__init__.py
+++ b/product_attribute_set_completeness/components/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import product_template_event_listener

--- a/product_attribute_set_completeness/components/product_template_event_listener.py
+++ b/product_attribute_set_completeness/components/product_template_event_listener.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.addons.component.core import Component
+
+
+class ProductTemplateEventListener(Component):
+    _name = "product.template.event.listener"
+    _inherit = ["attribute.set.owner.event.listener"]
+
+    _apply_on = ["product.template"]


### PR DESCRIPTION
As completion fields are used a lot for searches purposes, we need to store them in the database to speed up results.
As we can not simply use `store=True` because the depends fields are variable and dynamically defined on the attribute_set, this PR aims to use en event listener at each write/create