### PR TITLE
[12.0] improve UI on attribute_set_completeness

### DIFF
--- a/attribute_set_completeness/models/attribute_set_completeness.py
+++ b/attribute_set_completeness/models/attribute_set_completeness.py
@@ -1,7 +1,7 @@
 # Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AttributeSetCompleteness(models.Model):
@@ -12,6 +12,12 @@ class AttributeSetCompleteness(models.Model):
 
     attribute_set_id = fields.Many2one(
         "attribute.set", required=True, ondelete="cascade"
+    )
+    available_field_ids = fields.Many2many(
+        string="Attribute Set's fields",
+        comodel_name="ir.model.fields",
+        compute="_compute_available_field_ids",
+        help="Fields related to the Attribute set's attributes",
     )
     field_id = fields.Many2one(
         "ir.model.fields", "Field Name", required=True, ondelete="cascade"
@@ -25,6 +31,16 @@ class AttributeSetCompleteness(models.Model):
     completion_rate = fields.Float()
     completion_rate_progress = fields.Float(related="completion_rate", readonly=True)
     model_id = fields.Many2one(related="attribute_set_id.model_id", readonly=True)
+
+    @api.depends("attribute_set_id")
+    def _compute_available_field_ids(self):
+        for rec in self:
+            att_set_field_ids = rec.attribute_set_id.attribute_ids.mapped("field_id")
+
+            att_set_complete_ids = rec.attribute_set_id.attribute_set_completeness_ids
+            choosen_field_ids = att_set_complete_ids.mapped("field_id")
+
+            rec.available_field_ids = att_set_field_ids - choosen_field_ids
 
     def name_get(self):
         return [(rec.id, rec.field_id.field_description) for rec in self]

--- a/attribute_set_completeness/models/attribute_set_completeness.py
+++ b/attribute_set_completeness/models/attribute_set_completeness.py
@@ -25,3 +25,6 @@ class AttributeSetCompleteness(models.Model):
     completion_rate = fields.Float()
     completion_rate_progress = fields.Float(related="completion_rate", readonly=True)
     model_id = fields.Many2one(related="attribute_set_id.model_id", readonly=True)
+
+    def name_get(self):
+        return [(rec.id, rec.field_id.field_description) for rec in self]

--- a/attribute_set_completeness/views/attribute_set_completeness.xml
+++ b/attribute_set_completeness/views/attribute_set_completeness.xml
@@ -10,8 +10,9 @@
         <field name="arch" type="xml">
             <tree editable="bottom">
                 <field name="attribute_set_id" invisible="1" />
+                <field name="available_field_ids" invisible="1" />
                 <field name="model_id" />
-                <field name="field_id" domain="[('model_id', '=', model_id)]" />
+                <field name="field_id" domain="[('id', 'in', available_field_ids)]" />
                 <field name="field_description" />
                 <field name="completion_rate" sum="Total" />
                 <field

--- a/attribute_set_completeness/views/attribute_set_completeness.xml
+++ b/attribute_set_completeness/views/attribute_set_completeness.xml
@@ -12,7 +12,11 @@
                 <field name="attribute_set_id" invisible="1" />
                 <field name="available_field_ids" invisible="1" />
                 <field name="model_id" />
-                <field name="field_id" domain="[('id', 'in', available_field_ids)]" />
+                <field
+                    name="field_id"
+                    domain="[('id', 'in', available_field_ids)]"
+                    options="{'no_create': True}"
+                />
                 <field name="field_description" />
                 <field name="completion_rate" sum="Total" />
                 <field

--- a/pim/views/product_view.xml
+++ b/pim/views/product_view.xml
@@ -33,7 +33,7 @@
                 />
                 <field
                     name="completion_rate"
-                    widget="percentage"
+                    widget="progressbar"
                     attrs="{'invisible': ['|', ('attribute_set_id', '=', False),
                                                       ('completion_state', '=', 'complete')]}"
                 />

--- a/pim/views/product_view.xml
+++ b/pim/views/product_view.xml
@@ -25,17 +25,18 @@
                     groups="uom.group_uom"
                 />
                 <field name="attribute_set_id" />
+                <field name="attribute_set_not_completed_ids" invisible="1" />
                 <field
                     widget='label_selection'
                     name="completion_state"
                     options="{'classes': {'complete': 'success', 'not_complete':'danger'}}"
-                    attrs="{'invisible': [('attribute_set_id', '=', False)]}"
+                    attrs="{'invisible': ['|', ('attribute_set_id', '=', False), ('attribute_set_not_completed_ids', '=', [])]}"
                 />
                 <field
                     name="completion_rate"
                     widget="progressbar"
-                    attrs="{'invisible': ['|', ('attribute_set_id', '=', False),
-                                                      ('completion_state', '=', 'complete')]}"
+                    attrs="{'invisible': ['|', '|', ('attribute_set_id', '=', False),
+                        ('completion_state', '=', 'complete'), ('attribute_set_not_completed_ids', '=', [])]}"
                 />
             </tree>
         </field>

--- a/product_attribute_set_completeness/views/product_template_view.xml
+++ b/product_attribute_set_completeness/views/product_template_view.xml
@@ -36,7 +36,7 @@
                     name="completion_state"
                     nolabel="1"
                     options="{'classes': {'complete': 'success', 'not_complete':'danger'}}"
-                    attrs="{'invisible': [('attribute_set_id', '=', False)]}"
+                    attrs="{'invisible': ['|', ('attribute_set_id', '=', False), ('attribute_set_not_completed_ids', '=', [])]}"
                     class="ml-3"
                 />
                 <div>
@@ -44,8 +44,8 @@
                         name="completion_rate"
                         widget="progressbar"
                         nolabel="1"
-                        attrs="{'invisible': ['|', ('attribute_set_id', '=', False),
-                                                      ('completion_state', '=', 'complete')]}"
+                        attrs="{'invisible': ['|', '|', ('attribute_set_id', '=', False),
+                            ('completion_state', '=', 'complete'), ('attribute_set_not_completed_ids', '=', [])]}"
                     />
                 </div>
                 <field name="attribute_set_completeneness_ids" invisible="1" />
@@ -70,7 +70,7 @@
                 <filter
                     string="Not Complete"
                     name="filter_not_complete"
-                    domain="[('completion_state', '=', 'not_complete')]"
+                    domain="[('completion_state', '=', 'not_complete'), ('attribute_set_not_completed_ids', '!=', [])]"
                 />
             </filter>
         </field>

--- a/product_attribute_set_completeness/views/product_template_view.xml
+++ b/product_attribute_set_completeness/views/product_template_view.xml
@@ -12,11 +12,10 @@
             ref="product_attribute_set.product_template_form_view"
         />
         <field name="arch" type="xml">
-            <header position="after">
-
-            </header>
             <xpath expr="//separator[@name='attributes_placeholder']" position="before">
-                <group>
+                <div
+                    attrs="{'invisible': [('attribute_set_not_completed_ids', '=', [])]}"
+                >
                     <group>
                         <label
                             for="attribute_set_not_completed_ids"
@@ -28,33 +27,29 @@
                             widget="many2many_tags"
                         />
                     </group>
-                </group>
-            </xpath>
-            <xpath expr="//field[@name='attribute_set_id']/.." position="after">
-                <div>
-                    <field name="attribute_set_completeneness_ids" invisible="1" />
-                    <group
-                        string="Completion"
-                        attrs="{'invisible': [('attribute_set_completeneness_ids', '=', [])]}"
-                    >
-                        <group>
-                            <field
-                                widget='label_selection'
-                                name="completion_state"
-                                nolabel="1"
-                                options="{'classes': {'complete': 'success', 'not_complete':'danger'}}"
-                                attrs="{'invisible': [('attribute_set_id', '=', False)]}"
-                            />
-                            <field
-                                name="completion_rate"
-                                widget="progressbar"
-                                nolabel="1"
-                                attrs="{'invisible': ['|', ('attribute_set_id', '=', False),
-                                                              ('completion_state', '=', 'complete')]}"
-                            />
-                        </group>
-                    </group>
+                    <separator style="border-bottom-style: inset;" />
                 </div>
+            </xpath>
+            <xpath expr="//field[@name='attribute_set_id']" position="after">
+                <field
+                    widget='label_selection'
+                    name="completion_state"
+                    nolabel="1"
+                    options="{'classes': {'complete': 'success', 'not_complete':'danger'}}"
+                    attrs="{'invisible': [('attribute_set_id', '=', False)]}"
+                    class="ml-3"
+                />
+                <div>
+                    <field
+                        name="completion_rate"
+                        widget="progressbar"
+                        nolabel="1"
+                        attrs="{'invisible': ['|', ('attribute_set_id', '=', False),
+                                                      ('completion_state', '=', 'complete')]}"
+                    />
+                </div>
+                <field name="attribute_set_completeneness_ids" invisible="1" />
+                <separator />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Small UI improvements related to the attribute_set_completeness module : 

- The first commit improve slightly the product's form view, changing from :
![image](https://user-images.githubusercontent.com/31664455/96311657-59e1e700-0fe0-11eb-977d-e28f65c17736.png)
to :
![image](https://user-images.githubusercontent.com/31664455/96311719-80078700-0fe0-11eb-91f6-a3c977d6a664.png)

- The second commit change the attribute_set_completeness's domain to ease the fields selection and avoid duplicates.
- The third one hide the product's completeness state and rate if there isn't any attribute defined to be filled for its given attribute set (i.e. if product's attribute_set_completeness_ids is empty)

Cc @Cedric-Pigeon @rvalyi 