### PR TITLE
[IMP] add group_product_variant on Variants menus

### DIFF
--- a/pim/views/pim_view.xml
+++ b/pim/views/pim_view.xml
@@ -20,6 +20,7 @@
         id="main_menu_variant_attribute"
         name="Variants Attributes"
         parent="root_menu_pim"
+        groups="product.group_product_variant"
         sequence="10"
     />
     <menuitem
@@ -42,6 +43,7 @@
         name="Product Variants"
         action="product.product_normal_action_sell"
         parent="main_menu_product"
+        groups="product.group_product_variant"
         sequence="1"
     />
     <!-- Menu Attributes -->


### PR DESCRIPTION
I believe it will help a lot not to confuse the users when not using Variants products (which is the idea when using attribute_set, isn't it ?).

@sebastienbeau I don't know why I've a very slight memory of you telling me that we should not add these groups here... But I'm not sure of that... Anyway, thinking about it right now I really think it could be very useful. If not, let me know why ! Thanks !

cc @lmignon 