### PR TITLE
[FIX] Not able to create 'select' or 'multi-select' field 

### DIFF
--- a/attribute_set/wizard/attribute_option_wizard.py
+++ b/attribute_set/wizard/attribute_option_wizard.py
@@ -45,9 +45,13 @@ class AttributeOptionWizard(models.TransientModel):
                 }
             )
 
+        del vals['option_ids']
         res = super().create(vals)
-
         return res
+
+    def read(self, fields=None, load='_classic_read'):
+        fields.remove('option_ids')
+        return super().read(fields, load)
 
     @api.model
     def fields_view_get(


### PR DESCRIPTION
`fields_view_get` method is used to add a dynamic fields `option_ids` on the view, however, the `create` and `read` method will raise error when the required field is not in the `_fields` property of the given model instead of ignoring it in the previous versions.

Override `create` and `read` method to remove the `option_ids` field.

