### PR TITLE
[14.0][FIX] Add "Attribute Groups" item to Technical menu

### DIFF
--- a/attribute_set/views/attribute_group_view.xml
+++ b/attribute_set/views/attribute_group_view.xml
@@ -35,4 +35,18 @@
             </search>
         </field>
     </record>
+    <record id="attribute_group_form_action" model="ir.actions.act_window">
+        <field name="name">Attribute Groups</field>
+        <field name="res_model">attribute.group</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="attribute_group_search_view" />
+        <field name="context">{}</field>
+        <field name="help" />
+    </record>
+    <menuitem
+        action="attribute_group_form_action"
+        id="menu_attribute_group_action"
+        parent="menu_attribute_in_admin"
+        sequence="20"
+    />
 </odoo>


### PR DESCRIPTION
Adds an entry to view and edit attribute groups in the Settings > Technical > Database Structure > Attributes menu.

![2022-09-25_21-09-42_selection](https://user-images.githubusercontent.com/10487071/192161051-b067da69-1f24-4c86-8025-cb886ee0a1ba.png)