### PR TITLE
[15.0][FIX] attribute_set: fix crash when attempting to create options with a related model

### DIFF
--- a/attribute_set/wizard/attribute_option_wizard.py
+++ b/attribute_set/wizard/attribute_option_wizard.py
@@ -44,10 +44,16 @@ class AttributeOptionWizard(models.TransientModel):
                     "value_ref": "{},{}".format(attr.relation_model_id.model, op_id),
                 }
             )
+        if vals.get("option_ids"):
+            del vals["option_ids"]
+        return super().create(vals)
 
-        res = super().create(vals)
-
-        return res
+    # Hack to circumvent the fact that option_ids never actually exists in the DB,
+    # thus crashing when read is called after create
+    def read(self, fields=None, load="_classic_read"):
+        if "option_ids" in fields:
+            fields.remove("option_ids")
+        return super().read(fields, load)
 
     @api.model
     def fields_view_get(


### PR DESCRIPTION
when you define an attribute as a select field and add a related model, you have the option to "Load attribute options"

on this wizard, an "option_ids" dummy field is created via fields_view_get

this PR deletes option_ids from create (once the options are created) and read