### PR TITLE
[14.0][FIX] attribute_set: fix missing column

### DIFF
--- a/attribute_set/__manifest__.py
+++ b/attribute_set/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Attribute Set",
-    "version": "14.0.1.3.0",
+    "version": "14.0.1.3.1",
     "category": "Generic Modules/Others",
     "license": "AGPL-3",
     "author": "Akretion,Odoo Community Association (OCA)",

--- a/attribute_set/migrations/14.0.1.3.1/pre-migration.py
+++ b/attribute_set/migrations/14.0.1.3.1/pre-migration.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Akretion
+# @author: Raphaël Reverdy <raphael.reverdy@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    # 14.0.1.3.0 adds field company_dependent
+    # but ['ir.model']._instanciate_attrs is
+    # run before the creation of the column
+    # by the ORM
+    cr.execute(
+        "ALTER TABLE attribute_attribute ADD COLUMN IF NOT EXISTS company_dependent boolean"
+    )


### PR DESCRIPTION
14.0.1.3.0 adds field company_dependent
but ['ir.model']._instanciate_attrs is
run before the creation of the column
by the ORM