### PR TITLE
[FIX] attribute_set: Force load of attributes

### DIFF
--- a/attribute_set/models/attribute_set_owner.py
+++ b/attribute_set/models/attribute_set_owner.py
@@ -80,3 +80,17 @@ class AttributeSetOwnerMixin(models.AbstractModel):
                 result["views"]["form"]["arch"]
             )
         return result
+
+    @api.model
+    def _get_view_fields(self, view_type, models):
+        models = super()._get_view_fields(view_type, models)
+        if self._name in models and view_type == "form":
+            # we must ensure that the fields defined in the attributes set
+            # are declared into the list of fields to load for the form view
+            domain = [
+                ("model_id.model", "=", self._name),
+                ("attribute_set_ids", "!=", False),
+            ]
+            attributes = self.env["attribute.attribute"].search(domain)
+            models[self._name].update(attributes.mapped("name"))
+        return models

--- a/attribute_set/models/attribute_set_owner.py
+++ b/attribute_set/models/attribute_set_owner.py
@@ -22,7 +22,7 @@ class AttributeSetOwnerMixin(models.AbstractModel):
         """Override Attribute's method _build_attribute_eview() to build an
         attribute eview with the mixin model's attributes"""
         domain = [
-            ("model_id.model", "=", self._name),
+            ("model", "=", self._name),
             ("attribute_set_ids", "!=", False),
         ]
         if not self._context.get("include_native_attribute"):
@@ -36,7 +36,7 @@ class AttributeSetOwnerMixin(models.AbstractModel):
         """Remove native fields related to native attributes from eview"""
         native_attrs = self.env["attribute.attribute"].search(
             [
-                ("model_id.model", "=", self._name),
+                ("model", "=", self._name),
                 ("attribute_set_ids", "!=", False),
                 ("nature", "=", "native"),
             ]
@@ -88,9 +88,9 @@ class AttributeSetOwnerMixin(models.AbstractModel):
             # we must ensure that the fields defined in the attributes set
             # are declared into the list of fields to load for the form view
             domain = [
-                ("model_id.model", "=", self._name),
+                ("model", "=", self._name),
                 ("attribute_set_ids", "!=", False),
             ]
             attributes = self.env["attribute.attribute"].search(domain)
-            models[self._name].update(attributes.mapped("name"))
+            models[self._name].update(attributes.sudo().mapped("name"))
         return models

--- a/attribute_set/tests/test_build_view.py
+++ b/attribute_set/tests/test_build_view.py
@@ -304,3 +304,14 @@ class BuildViewCase(TransactionCase):
         self.assertTrue(
             self.env["ir.model.fields"].browse([attr_native_field_id]).exists()
         )
+
+    def test_models_fields_for_get_views(self):
+        # this test is here to ensure that attributes defined in attribute_set
+        # and added to the view are correctly added to the list of fields
+        # to load for the view
+        result = self.env["res.partner"].get_views([(self.view.id, "form")])
+        fields = result["models"].get("res.partner")
+        self.assertIn("x_attr_1", fields)
+        self.assertIn("x_attr_2", fields)
+        self.assertIn("x_attr_3", fields)
+        self.assertIn("x_attr_4", fields)


### PR DESCRIPTION
Add all the attributes defined for the model into the list of fields to load to display the form view. Wihout this change a JS error occurs when displaying the form view of a x2many field for a model defining attributes. The origin of the error comes from the the get_views method which is called for the type 'form' only. In this case it's important to add all the custom attributes to the list of fields defined on the model for the view. When the same method is called without restriction it will load all the views. Since odoo include all the fields defined on the model for the search view, the error doesn't occur when using the form view from a menu action.