### PR TITLE
[16.0][IMP] product_attribute_set: allow displaying attributes for product variants

### DIFF
--- a/attribute_set/models/attribute_attribute.py
+++ b/attribute_set/models/attribute_attribute.py
@@ -97,6 +97,10 @@ class AttributeAttribute(models.Model):
         column1="attribute_id",
         column2="attribute_set_id",
     )
+    allowed_attribute_set_ids = fields.Many2many(
+        comodel_name="attribute.set",
+        compute="_compute_allowed_attribute_set_ids",
+    )
 
     attribute_group_id = fields.Many2one(
         "attribute.group", "Attribute Group", required=True, ondelete="cascade"
@@ -223,6 +227,18 @@ class AttributeAttribute(models.Model):
             attribute_with_env._build_attribute_field(attribute_egroup)
 
         return attribute_eview
+
+    def _get_attribute_set_allowed_model(self):
+        return self.model_id
+
+    @api.depends("model_id")
+    def _compute_allowed_attribute_set_ids(self):
+        AttributeSet = self.env["attribute.set"]
+        for record in self:
+            allowed_models = record._get_attribute_set_allowed_model()
+            record.allowed_attribute_set_ids = AttributeSet.search(
+                [("model_id", "in", allowed_models.ids)]
+            )
 
     @api.onchange("model_id")
     def onchange_model_id(self):

--- a/attribute_set/views/attribute_attribute_view.xml
+++ b/attribute_set/views/attribute_attribute_view.xml
@@ -72,10 +72,11 @@
                         domain="[('model_id', '=', model_id)]"
                     />
                     <field name="sequence" />
+                    <field name="allowed_attribute_set_ids" invisible="1" />
                     <field
                         name="attribute_set_ids"
                         widget="many2many_tags"
-                        domain="[('model_id', '=', model_id)]"
+                        domain="[('id', 'in', allowed_attribute_set_ids)]"
                         options="{'no_create': 1}"
                         invisible="context.get('from_attribute_set')"
                     />

--- a/product_attribute_set/models/__init__.py
+++ b/product_attribute_set/models/__init__.py
@@ -1,2 +1,3 @@
+from . import attribute_attribute
 from . import product_category
 from . import product

--- a/product_attribute_set/models/attribute_attribute.py
+++ b/product_attribute_set/models/attribute_attribute.py
@@ -1,0 +1,14 @@
+# Copyright 2023 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AttributeAttribute(models.Model):
+    _inherit = "attribute.attribute"
+
+    def _get_attribute_set_allowed_model(self):
+        res = super()._get_attribute_set_allowed_model()
+        if self.model_id.model == "product.product":
+            res |= self.env["ir.model"].search([("model", "=", "product.template")])
+        return res

--- a/product_attribute_set/models/product.py
+++ b/product_attribute_set/models/product.py
@@ -48,5 +48,15 @@ class ProductTemplate(models.Model):
             self.attribute_set_id = self.categ_id.attribute_set_id
 
 
-# TODO : add the 'attribute.set.owner.mixin' to product.product in order to display
-# Attributes in Variants.
+class ProductProduct(models.Model):
+
+    _inherit = ["product.product", "attribute.set.owner.mixin"]
+    _name = "product.product"
+
+    attribute_set_id = fields.Many2one(
+        related="product_tmpl_id.attribute_set_id", store=True
+    )
+
+    @api.model
+    def _get_attribute_set_owner_model(self):
+        return [("model", "in", ("product.product", "product.template"))]

--- a/product_attribute_set/views/product.xml
+++ b/product_attribute_set/views/product.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <!-- Product Template -->
     <record id="product.product_template_action" model="ir.actions.act_window">
         <field name="context">
             {"include_native_attribute": 1, "search_default_filter_to_sell": 1}
@@ -46,6 +47,17 @@
                     context="{'group_by': 'attribute_set_id'}"
                 />
             </xpath>
+        </field>
+    </record>
+    <!-- Product Variant -->
+    <record id="product.product_normal_action" model="ir.actions.act_window">
+        <field name="context">
+            {"include_native_attribute": 1}
+        </field>
+    </record>
+    <record id="product.product_normal_action_sell" model="ir.actions.act_window">
+        <field name="context">
+            {"include_native_attribute": 1, "search_default_filter_to_sell": 1}
         </field>
     </record>
     <!-- Do not display all the attributes in the easy edit view -->

--- a/product_attribute_set/views/product.xml
+++ b/product_attribute_set/views/product.xml
@@ -17,6 +17,7 @@
                         name="attribute_set_id"
                         nolabel="1"
                         context="{'default_model_id': %(product.model_product_template)d}"
+                        force_save="1"
                     />
                 </div>
             </xpath>
@@ -44,6 +45,23 @@
                     string="Attribute Set"
                     context="{'group_by': 'attribute_set_id'}"
                 />
+            </xpath>
+        </field>
+    </record>
+    <!-- Do not display all the attributes in the easy edit view -->
+    <record id="product_variant_easy_edit_view" model="ir.ui.view">
+        <field
+            name="name"
+        >product.product.view.form.easy - product_attribute_set</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_variant_easy_edit_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='packaging']/.." position="after">
+                <group>
+                    <group name="product_attributes" string="Attributes" invisible="1">
+                        <separator name="attributes_placeholder" />
+                    </group>
+                </group>
             </xpath>
         </field>
     </record>

--- a/product_attribute_set/views/product_category.xml
+++ b/product_attribute_set/views/product_category.xml
@@ -8,7 +8,7 @@
             <field name="parent_id" position="after">
                 <field
                     name="attribute_set_id"
-                    domain="[('model_id', '=', 'product.template')]"
+                    domain="[('model_id', 'in', ('product.template', 'product.product'))]"
                     class="oe_inline"
                 />
             </field>


### PR DESCRIPTION
- Add mixin to product_product model
- Assign attribute set from product template. Allow product_product to have a set related to product_template assigned.
- Add placeholder to easy edit form view (maybe it should be invisible to not overload the easy edit view)
- Allow linking a product variant attribute to a product template set, as the attribute set is managed in the template.
- Show native fields in product variant view.