### PR TITLE
[14.0][FIX] product_attribute_set: Overwrite of the attribute set by category

### DIFF
--- a/product_attribute_set/models/product.py
+++ b/product_attribute_set/models/product.py
@@ -40,10 +40,17 @@ class ProductTemplate(models.Model):
         return super().create(vals)
 
     def write(self, vals):
-        if not vals.get("attribute_set_id") and vals.get("categ_id"):
+        ret = super().write(vals)
+
+        if not vals.get("categ_id"):
+            return ret
+
+        recs = self.filtered_domain([("attribute_set_id", "=", False)])
+        if recs:
             category = self.env["product.category"].browse(vals["categ_id"])
-            vals["attribute_set_id"] = category.attribute_set_id.id
-        return super().write(vals)
+            recs.write({"attribute_set_id": category.attribute_set_id.id})
+
+        return ret
 
     @api.onchange("categ_id")
     def update_att_set_onchange_categ_id(self):


### PR DESCRIPTION
The option _attribute_set_id_ on _product.category_ is labeled to be the "Default Attribute Set" but if you change the product category of a product it will always overwrite the _attribute_set_id_ there if the attribute set of the product isn't set at the same time. The behaviour is also different from the onchange of _categ_id_. This is in all versions.

The patch will only copy the _attribute_set_id_ from the category if it isn't already set on the product.