### PR TITLE
[IMP][FIX] attribute_set: improve wizard functionality and tests

### DIFF
--- a/attribute_set/wizard/attribute_option_wizard.py
+++ b/attribute_set/wizard/attribute_option_wizard.py
@@ -22,6 +22,10 @@ class AttributeOptionWizard(models.TransientModel):
         default=lambda self: self.env.context.get("attribute_id", False),
         ondelete="cascade",
     )
+    option_ids = fields.Many2many(
+        "attribute.option",
+        string="Attribute Options",
+    )
 
     def validate(self):
         return True
@@ -38,6 +42,8 @@ class AttributeOptionWizard(models.TransientModel):
                 model = attr.relation_model_id.model
 
                 name = self.env[model].browse(op_id).name_get()[0][1]
+                vals["option_ids"][0][1] = name
+                vals["option_ids"][0][0] = [vals["attribute_id"]]
                 opt_obj.create(
                     {
                         "attribute_id": vals["attribute_id"],
@@ -47,16 +53,7 @@ class AttributeOptionWizard(models.TransientModel):
                         ),
                     }
                 )
-            if vals.get("option_ids"):
-                del vals["option_ids"]
         return super().create(vals_list)
-
-    # Hack to circumvent the fact that option_ids never actually exists in the DB,
-    # thus crashing when read is called after create
-    def read(self, fields=None, load="_classic_read"):
-        if "option_ids" in fields:
-            fields.remove("option_ids")
-        return super().read(fields, load)
 
     @api.model
     def get_views(self, views, options=None):
@@ -88,7 +85,7 @@ class AttributeOptionWizard(models.TransientModel):
             )
 
             eview = etree.fromstring(res["views"]["form"]["arch"])
-            options = etree.Element("field", name="option_ids", nolabel="1")
+            options = etree.Element("field", name="option_ids", widget="many2many_tags")
             placeholder = eview.xpath("//separator[@string='options_placeholder']")[0]
             placeholder.getparent().replace(placeholder, options)
             res["views"]["form"]["arch"] = etree.tostring(eview, pretty_print=True)


### PR DESCRIPTION
The wizard had a bad designed field for option_ids that is supposed to simulate many2many field.
I added many2many tags to it and some useful test cases from a commit getting merged in 14.0 too.
On the way to migrate to 18.0 without any old or new issues.

![Screenshot from 2025-02-16 09-58-49](https://github.com/user-attachments/assets/d54195fa-7ec6-45dc-9bb3-9d9f291e5974)
