### PR TITLE
[19.0][IMP] attribute_set: add hierarchy support to attribute sets

### DIFF
--- a/attribute_set/models/attribute_attribute.py
+++ b/attribute_set/models/attribute_attribute.py
@@ -117,12 +117,24 @@ class AttributeAttribute(models.Model):
         "Sequence in Group", help="The attribute's order in his group"
     )
 
+    def _get_all_set_ids(self):
+        """Return IDs of attribute sets where this attribute should be visible.
+
+        Includes all descendant sets of the attribute's direct sets,
+        so that child sets inherit their parent's attributes.
+        """
+        self.ensure_one()
+        return (
+            self.env["attribute.set"]
+            .search([("id", "child_of", self.attribute_set_ids.ids)])
+            .ids
+        )
+
     def _get_attrs(self):
-        attrs = {"invisible": f"attribute_set_id not in {self.attribute_set_ids.ids}"}
+        all_set_ids = self._get_all_set_ids()
+        attrs = {"invisible": f"attribute_set_id not in {all_set_ids}"}
         if self.required or self.required_on_views:
-            attrs.update(
-                {"required": f"attribute_set_id in {self.attribute_set_ids.ids}"}
-            )
+            attrs.update({"required": f"attribute_set_id in {all_set_ids}"})
         return attrs
 
     @api.model
@@ -214,9 +226,16 @@ class AttributeAttribute(models.Model):
                 att_set_ids = []
                 for att in att_group.attribute_ids:
                     att_set_ids += att.attribute_set_ids.ids
+                # Expand to include all descendant sets so that child
+                # sets inherit their parent's attribute groups
+                all_set_ids = (
+                    self.env["attribute.set"]
+                    .search([("id", "child_of", list(set(att_set_ids)))])
+                    .ids
+                )
                 # Hide the Group if none of its attributes are in
                 # the destination object's Attribute set
-                hide_condition = f"attribute_set_id not in {list(set(att_set_ids))}"
+                hide_condition = f"attribute_set_id not in {all_set_ids}"
                 attribute_egroup = etree.SubElement(
                     attribute_eview,
                     "group",

--- a/attribute_set/models/attribute_set.py
+++ b/attribute_set/models/attribute_set.py
@@ -4,14 +4,30 @@
 # Copyright 2015 Savoir-faire Linux
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class AttributeSet(models.Model):
     _name = "attribute.set"
     _description = "Attribute Set"
+    _parent_name = "parent_id"
+    _parent_store = True
 
     name = fields.Char(required=True, translate=True)
+    parent_id = fields.Many2one(
+        comodel_name="attribute.set",
+        string="Parent Set",
+        index=True,
+        ondelete="restrict",
+        domain="[('model_id', '=', model_id)]",
+    )
+    parent_path = fields.Char(index=True)
+    child_ids = fields.One2many(
+        comodel_name="attribute.set",
+        inverse_name="parent_id",
+        string="Child Sets",
+    )
 
     attribute_ids = fields.Many2many(
         comodel_name="attribute.attribute",
@@ -19,6 +35,12 @@ class AttributeSet(models.Model):
         relation="rel_attribute_set",
         column1="attribute_set_id",
         column2="attribute_id",
+    )
+    complete_attribute_ids = fields.Many2many(
+        comodel_name="attribute.attribute",
+        string="All Attributes (inherited)",
+        compute="_compute_complete_attribute_ids",
+        recursive=True,
     )
     model_id = fields.Many2one("ir.model", "Model", required=True, ondelete="cascade")
     model = fields.Char(
@@ -28,3 +50,31 @@ class AttributeSet(models.Model):
         help="This is a technical field in order to build filters on this one to avoid"
         "access on ir.model",
     )
+
+    @api.depends("attribute_ids", "parent_id.complete_attribute_ids")
+    def _compute_complete_attribute_ids(self):
+        for rec in self:
+            attributes = rec.attribute_ids
+            parent = rec.parent_id
+            while parent:
+                attributes |= parent.attribute_ids
+                parent = parent.parent_id
+            rec.complete_attribute_ids = attributes
+
+    @api.constrains("parent_id")
+    def _check_parent_id(self):
+        if self._has_cycle():
+            raise ValidationError(
+                self.env._("Error! You cannot create recursive attribute sets.")
+            )
+
+    @api.constrains("parent_id", "model_id")
+    def _check_parent_model(self):
+        for rec in self:
+            if rec.parent_id and rec.parent_id.model_id != rec.model_id:
+                raise ValidationError(
+                    self.env._(
+                        "The parent attribute set must belong to the same"
+                        " model as the child."
+                    )
+                )

--- a/attribute_set/tests/__init__.py
+++ b/attribute_set/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_custom_attribute
 from . import test_build_view
 from . import test_native_field_creation
+from . import test_attribute_set_hierarchy

--- a/attribute_set/tests/test_attribute_set_hierarchy.py
+++ b/attribute_set/tests/test_attribute_set_hierarchy.py
@@ -1,0 +1,139 @@
+# Copyright 2025 ForgeFlow (http://www.forgeflow.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import UserError, ValidationError  # noqa: F401
+from odoo.tests import TransactionCase
+
+
+class TestAttributeSetHierarchy(TransactionCase):
+    @classmethod
+    def _create_set(cls, name, parent=None):
+        vals = {"name": name, "model_id": cls.model_id}
+        if parent:
+            vals["parent_id"] = parent.id
+        return cls.env["attribute.set"].create(vals)
+
+    @classmethod
+    def _create_group(cls, vals):
+        vals["model_id"] = cls.model_id
+        return cls.env["attribute.group"].create(vals)
+
+    @classmethod
+    def _create_attribute(cls, vals):
+        vals["model_id"] = cls.model_id
+        return cls.env["attribute.attribute"].create(vals)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.model_id = cls.env.ref("base.model_res_partner").id
+
+        # Create hierarchy: parent_set -> child_set -> grandchild_set
+        cls.parent_set = cls._create_set("Parent Set")
+        cls.child_set = cls._create_set("Child Set", parent=cls.parent_set)
+        cls.grandchild_set = cls._create_set("Grandchild Set", parent=cls.child_set)
+        cls.sibling_set = cls._create_set("Sibling Set", parent=cls.parent_set)
+
+        cls.group = cls._create_group({"name": "Test Group", "sequence": 1})
+
+        # Attribute on parent set only
+        cls.parent_attr = cls._create_attribute(
+            {
+                "nature": "custom",
+                "name": "x_parent_attr",
+                "attribute_type": "char",
+                "sequence": 1,
+                "attribute_group_id": cls.group.id,
+                "attribute_set_ids": [(6, 0, [cls.parent_set.id])],
+            }
+        )
+
+        # Attribute on child set only
+        cls.child_attr = cls._create_attribute(
+            {
+                "nature": "custom",
+                "name": "x_child_attr",
+                "attribute_type": "char",
+                "sequence": 2,
+                "attribute_group_id": cls.group.id,
+                "attribute_set_ids": [(6, 0, [cls.child_set.id])],
+            }
+        )
+
+    def test_complete_attribute_ids_leaf(self):
+        """Grandchild set should inherit attributes from child and parent."""
+        self.assertEqual(
+            self.grandchild_set.complete_attribute_ids,
+            self.parent_attr | self.child_attr,
+        )
+
+    def test_complete_attribute_ids_child(self):
+        """Child set should inherit attributes from parent plus its own."""
+        self.assertEqual(
+            self.child_set.complete_attribute_ids,
+            self.parent_attr | self.child_attr,
+        )
+
+    def test_complete_attribute_ids_parent(self):
+        """Parent set should only have its own attributes."""
+        self.assertEqual(
+            self.parent_set.complete_attribute_ids,
+            self.parent_attr,
+        )
+
+    def test_complete_attribute_ids_sibling(self):
+        """Sibling set should inherit from parent but not from child."""
+        self.assertEqual(
+            self.sibling_set.complete_attribute_ids,
+            self.parent_attr,
+        )
+
+    def test_visibility_parent_attr_includes_descendants(self):
+        """Parent attribute should be visible for all descendant sets."""
+        all_set_ids = self.parent_attr._get_all_set_ids()
+        self.assertIn(self.parent_set.id, all_set_ids)
+        self.assertIn(self.child_set.id, all_set_ids)
+        self.assertIn(self.grandchild_set.id, all_set_ids)
+        self.assertIn(self.sibling_set.id, all_set_ids)
+
+    def test_visibility_child_attr_excludes_parent(self):
+        """Child attribute should not be visible for the parent set."""
+        all_set_ids = self.child_attr._get_all_set_ids()
+        self.assertNotIn(self.parent_set.id, all_set_ids)
+        self.assertIn(self.child_set.id, all_set_ids)
+        self.assertIn(self.grandchild_set.id, all_set_ids)
+        self.assertNotIn(self.sibling_set.id, all_set_ids)
+
+    def test_eview_includes_descendant_set_ids(self):
+        """The generated view should include descendant set IDs."""
+        eview = self.env["res.partner"]._build_attribute_eview()
+        # Check group visibility includes all hierarchy IDs
+        group_elem = eview.find(".//group[@string='Test group']")
+        self.assertIsNotNone(group_elem)
+        invisible = group_elem.get("invisible")
+        for attr_set in (
+            self.parent_set,
+            self.child_set,
+            self.grandchild_set,
+            self.sibling_set,
+        ):
+            self.assertIn(str(attr_set.id), invisible)
+
+    def test_constraint_no_recursion(self):
+        """Setting parent_id to create a cycle should raise.
+
+        _parent_store detects recursion and raises UserError before the
+        @api.constrains fires.
+        """
+        with self.assertRaises(UserError):
+            self.parent_set.parent_id = self.grandchild_set.id
+
+    def test_constraint_same_model(self):
+        """Parent must have the same model_id as child."""
+        other_model_id = self.env.ref("base.model_res_country").id
+        other_set = self.env["attribute.set"].create(
+            {"name": "Other Model Set", "model_id": other_model_id}
+        )
+        with self.assertRaises(ValidationError):
+            self.child_set.parent_id = other_set.id

--- a/attribute_set/views/attribute_set_view.xml
+++ b/attribute_set/views/attribute_set_view.xml
@@ -12,8 +12,13 @@
                         invisible="context.get('default_model_id')"
                         class="oe_inline"
                     />
+                    <field
+                        name="parent_id"
+                        domain="[('model_id', '=', model_id)]"
+                        class="oe_inline"
+                    />
                 </group>
-                <group name="attributes" string="Attributes">
+                <group name="attributes" string="Own Attributes">
                     <field
                         name="attribute_ids"
                         colspan="4"
@@ -21,6 +26,22 @@
                         domain="[('model_id', '=', model_id)]"
                         nolabel="1"
                     >
+                        <list>
+                            <field name="name" />
+                            <field name="field_description" />
+                            <field name="attribute_type" />
+                            <field name="required" />
+                            <field name="sequence" />
+                            <field name="attribute_group_id" />
+                        </list>
+                    </field>
+                </group>
+                <group
+                    name="complete_attributes"
+                    string="All Attributes (inherited)"
+                    invisible="not parent_id"
+                >
+                    <field name="complete_attribute_ids" colspan="4" nolabel="1">
                         <list>
                             <field name="name" />
                             <field name="field_description" />
@@ -40,6 +61,7 @@
         <field name="arch" type="xml">
             <list>
                 <field name="name" />
+                <field name="parent_id" optional="show" />
                 <field name="model_id" />
             </list>
         </field>


### PR DESCRIPTION
Allow attribute sets to be organized in parent/child hierarchies so that assigning a child set to a record automatically includes all attributes from ancestor sets.

- Add parent_id, child_ids, parent_path with _parent_store
- Add complete_attribute_ids computed field (own + ancestors)
- Expand visibility logic to include descendant sets
- Add constraints for recursion and same-model parent
- Update form/tree views for hierarchy
- Add tests for hierarchy, visibility, and constraints