### PR TITLE
[19.0][IMP] website_attribute_set: add options to hide attribute in filter or in product view

### DIFF
--- a/website_attribute_set/controllers/main.py
+++ b/website_attribute_set/controllers/main.py
@@ -1,387 +1,55 @@
 # Copyright 2025 Kencove (http://www.kencove.com).
 # @author Mohamed Alkobrosli <malkobrosly@kencove.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-import itertools
-from datetime import datetime
 
-from odoo import fields
 from odoo.fields import Domain
-from odoo.http import request, route
+from odoo.http import request
 from odoo.models import BaseModel
-from odoo.tools import SQL, float_round, lazy
 
-from odoo.addons.website.controllers.main import QueryURL
-from odoo.addons.website_sale.const import SHOP_PATH
 from odoo.addons.website_sale.controllers import main
-from odoo.addons.website_sale.models.website import PRICELIST_SESSION_CACHE_KEY
 
 
 class WebsiteSale(main.WebsiteSale):
-    @route()
-    def shop(  # noqa: C901
-        self,
-        page=0,
-        category=None,
-        search="",
-        min_price=0.0,
-        max_price=0.0,
-        tags="",
-        **post,
-    ):
-        if not request.website.has_ecommerce_access():
-            return request.redirect(f"/web/login?redirect={request.httprequest.path}")
-
-        is_category_in_query = category and isinstance(category, str)
-        category = self._validate_and_get_category(category)
-        # If the category is provided as a query parameter (which is deprecated),
-        # we redirect to the "correct" shop URL, where the category has been
-        # removed from the query parameters and added to the path.
-        if is_category_in_query:
-            query = self._get_filtered_query_string(
-                request.httprequest.query_string.decode(), keys_to_remove=["category"]
-            )
-            return request.redirect(
-                f"{self._get_shop_path(category, page)}?{query}", code=301
-            )
-
-        try:
-            min_price = float(min_price)
-        except ValueError:
-            min_price = 0
-        try:
-            max_price = float(max_price)
-        except ValueError:
-            max_price = 0
-
-        website = request.env["website"].get_current_website()
-        website_domain = website.website_domain()
-
-        ppg = website.shop_ppg or 21
-        ppr = website.shop_ppr or 4
-        gap = website.shop_gap or "16px"
-
+    def _parse_additional_attrib_values(self):
+        """Parse additional_attribute_values params from the request."""
         request_args = request.httprequest.args
-        attribute_values = request_args.getlist("attribute_values")
-        attribute_value_dict = self._get_attribute_value_dict(attribute_values)
-        attribute_ids = set(attribute_value_dict.keys())
-        attribute_value_ids = set(
-            itertools.chain.from_iterable(attribute_value_dict.values())
-        )
-        if attribute_values:
-            request.session["attribute_values"] = attribute_values
-        else:
-            request.session.pop("attribute_values", None)
+        raw_list = request_args.getlist("additional_attribute_values")
+        parsed = [[x for x in v.split("-", maxsplit=1)] for v in raw_list if v]
+        return [[int(sublist[0]), sublist[1]] for sublist in parsed]
 
-        # START HOOK 1
-        additional_attribute_values = request_args.getlist(
-            "additional_attribute_values"
-        )
-        additional_attribute_values = self._get_additional_attribute_value_list(
-            additional_attribute_values
-        )
-        additional_attribute_set = set(tuple(x) for x in additional_attribute_values)
-        if additional_attribute_values:
-            request.session["additional_attribute_values"] = additional_attribute_values
-            post["additional_attribute_values"] = additional_attribute_values
-            post["additional_attribute_set"] = additional_attribute_set
-        else:
-            request.session.pop("additional_attribute_values", None)
-
-        # Parse range filter parameters (for numeric attributes)
-        additional_range_filters = {}
+    def _parse_additional_range_filters(self):
+        """Parse additional_attr_min_/max_ params from the request."""
+        request_args = request.httprequest.args
+        range_filters = {}
         for key in request_args.keys():
             if key.startswith("additional_attr_min_"):
                 attr_id = int(key.replace("additional_attr_min_", ""))
-                additional_range_filters.setdefault(attr_id, {})
+                if attr_id not in range_filters:
+                    range_filters[attr_id] = {}
                 try:
-                    additional_range_filters[attr_id]["min"] = float(request_args[key])
+                    range_filters[attr_id]["min"] = float(request_args[key])
                 except (ValueError, TypeError):
                     continue
             elif key.startswith("additional_attr_max_"):
                 attr_id = int(key.replace("additional_attr_max_", ""))
-                additional_range_filters.setdefault(attr_id, {})
+                if attr_id not in range_filters:
+                    range_filters[attr_id] = {}
                 try:
-                    additional_range_filters[attr_id]["max"] = float(request_args[key])
+                    range_filters[attr_id]["max"] = float(request_args[key])
                 except (ValueError, TypeError):
                     continue
-        if additional_range_filters:
-            request.session["additional_range_filters"] = additional_range_filters
-            post["additional_range_filters"] = additional_range_filters
-        else:
-            request.session.pop("additional_range_filters", None)
-        # END HOOK 1
+        return range_filters
 
-        filter_by_tags_enabled = website.is_view_active(
-            "website_sale.filter_products_tags"
+    def _shop_get_query_url_kwargs(self, search, min_price, max_price, **post):
+        result = super()._shop_get_query_url_kwargs(
+            search, min_price, max_price, **post
         )
-        if filter_by_tags_enabled:
-            if tags:
-                post["tags"] = tags
-                tags = {self.env["ir.http"]._unslug(tag)[1] for tag in tags.split(",")}
-            else:
-                post["tags"] = None
-                tags = {}
-
-        url = self._get_shop_path(category)
-        keep = QueryURL(
-            url, **self._shop_get_query_url_kwargs(search, min_price, max_price, **post)
+        additional_attrib_list = request.httprequest.args.getlist(
+            "additional_attribute_values"
         )
-
-        # Check if we need to refresh the cached pricelist
-        now = datetime.timestamp(datetime.now())
-        if "website_sale_pricelist_time" in request.session:
-            pricelist_save_time = request.session["website_sale_pricelist_time"]
-            if pricelist_save_time < now - 60 * 60:
-                request.session.pop(PRICELIST_SESSION_CACHE_KEY, None)
-                # restart the counter
-                request.session["website_sale_pricelist_time"] = now
-
-        filter_by_price_enabled = website.is_view_active(
-            "website_sale.filter_products_price"
-        )
-        if filter_by_price_enabled:
-            company_currency = website.company_id.sudo().currency_id
-            conversion_rate = request.env["res.currency"]._get_conversion_rate(
-                company_currency,
-                website.currency_id,
-                request.website.company_id,
-                fields.Date.today(),
-            )
-        else:
-            conversion_rate = 1
-
-        if search:
-            post["search"] = search
-
-        options = self._get_search_options(
-            category=category,
-            attribute_value_dict=attribute_value_dict,
-            min_price=min_price,
-            max_price=max_price,
-            conversion_rate=conversion_rate,
-            display_currency=website.currency_id,
-            **post,
-        )
-        fuzzy_search_term, product_count, search_product = self._shop_lookup_products(
-            options, post, search, website
-        )
-
-        filter_by_price_enabled = website.is_view_active(
-            "website_sale.filter_products_price"
-        )
-        if filter_by_price_enabled:
-            # TODO Find an alternative way to obtain
-            # the domain through the search metadata.
-            Product = request.env["product.template"].with_context(bin_size=True)
-            search_term = fuzzy_search_term if fuzzy_search_term else search
-            domain = self._get_shop_domain(search_term, category, attribute_value_dict)
-
-            # This is ~4 times more efficient than a search
-            # for the cheapest and most expensive products
-            query = Product._search(domain)
-            sql = query.select(
-                SQL(
-                    "COALESCE(MIN(list_price), 0) * %(conversion_rate)s, "
-                    "COALESCE(MAX(list_price), 0) * %(conversion_rate)s",
-                    conversion_rate=conversion_rate,
-                )
-            )
-            available_min_price, available_max_price = request.env.execute_query(sql)[0]
-
-            if min_price or max_price:
-                # The if/else condition in the min_price / max_price value assignment
-                # tackles the case where we switch to a list of products with different
-                # available min / max prices than the ones set in the previous page.
-                # In order to have logical results and not yield empty product lists,
-                # the price filter is set to their respective available prices
-                # when the specified min exceeds the max, and / or
-                # the specified max is lower than the available min.
-                if min_price:
-                    min_price = (
-                        min_price
-                        if min_price <= available_max_price
-                        else available_min_price
-                    )
-                    post["min_price"] = min_price
-                if max_price:
-                    max_price = (
-                        max_price
-                        if max_price >= available_min_price
-                        else available_max_price
-                    )
-                    post["max_price"] = max_price
-
-        ProductTag = request.env["product.tag"]
-        if filter_by_tags_enabled and search_product:
-            all_tags = ProductTag.search_fetch(
-                Domain.AND(
-                    [
-                        Domain("visible_to_customers", "=", True),
-                        Domain.OR(
-                            [
-                                Domain("product_template_ids.is_published", "=", True),
-                                Domain("product_ids.is_published", "=", True),
-                            ]
-                        ),
-                        website_domain,
-                    ]
-                )
-            )
-        else:
-            all_tags = ProductTag
-
-        # categories
-
-        Category = request.env["product.public.category"]
-        categs_domain = Domain("parent_id", "=", False) & website_domain
-        if not self.env.user._is_internal():
-            categs_domain &= Domain("has_published_products", "=", True)
-        if search:
-            search_categories = Category.search(
-                Domain("product_tmpl_ids", "in", search_product.ids) & website_domain
-            ).parents_and_self
-            categs_domain &= Domain("id", "in", search_categories.ids)
-        else:
-            search_categories = Category
-        categs = Category.search_fetch(categs_domain)
-
-        category_entries = Category
-        if category:
-            category_entries = (
-                not search
-                and category.child_id
-                or category.child_id.filtered(lambda c: c.id in search_categories.ids)
-            )
-            if not category_entries:
-                parent = category.parent_id
-                category_entries = (
-                    not search
-                    and parent.child_id
-                    or parent.child_id.filtered(lambda c: c.id in search_categories.ids)
-                )
-        else:
-            category_entries = categs
-        if not request.env.user._is_internal():
-            category_entries = category_entries.filtered("has_published_products")
-
-        # products for current pager
-
-        pager = website.pager(
-            url=url, total=product_count, page=page, step=ppg, scope=5, url_args=post
-        )
-        offset = pager["offset"]
-        products = search_product[offset : offset + ppg]
-        products.fetch()
-
-        # map each product to its variant, and prefetch the variants
-        variants = (
-            request.env["product.product"]
-            .sudo()
-            .browse(product._get_first_possible_variant_id() for product in products)
-        )
-        variants.fetch()
-        product_variants = dict(zip(products, variants, strict=False))
-
-        ProductAttribute = request.env["product.attribute"]
-        if products:
-            # get all products without limit
-            attributes_grouped = request.env[
-                "product.template.attribute.line"
-            ]._read_group(
-                domain=[
-                    ("product_tmpl_id", "in", search_product.ids),
-                    ("attribute_id.visibility", "=", "visible"),
-                ],
-                groupby=["attribute_id"],
-                order="attribute_id",
-            )
-            attribute_ids = [attribute.id for (attribute,) in attributes_grouped]
-            attributes = ProductAttribute.browse(attribute_ids)
-        else:
-            attributes = ProductAttribute.browse(attribute_ids).sorted()
-
-        if website.is_view_active("website_sale.products_list_view"):
-            layout_mode = "list"
-        else:
-            layout_mode = "grid"
-
-        products_prices = products._get_sales_prices(website)
-        product_query_params = self._get_product_query_params(**post)
-
-        grouped_attributes_values = (
-            request.env["product.attribute.value"]
-            .browse(attribute_value_ids)
-            .sorted()
-            .grouped("attribute_id")
-        )
-
-        values = {
-            "auto_assign_ribbons": self.env["product.ribbon"]
-            .sudo()
-            .search([("assign", "!=", "manual")]),
-            "search": fuzzy_search_term or search,
-            "original_search": fuzzy_search_term and search,
-            "order": post.get("order", ""),
-            "category": category,
-            "attrib_values": attribute_value_dict,
-            "attrib_set": attribute_value_ids,
-            # START HOOK 2
-            "additional_attrib_set": additional_attribute_set,
-            # END HOOK 2
-            "pager": pager,
-            "products": products,
-            "product_variants": product_variants,
-            "search_product": search_product,
-            "search_count": product_count,  # common for all searchbox
-            "bins": main.TableCompute().process(products, ppg, ppr),
-            "ppg": ppg,
-            "ppr": ppr,
-            "gap": gap,
-            "categories": categs,
-            "category_entries": category_entries,
-            "attributes": attributes,
-            "keep": keep,
-            "search_categories_ids": search_categories.ids,
-            "layout_mode": layout_mode,
-            "get_product_prices": lambda product: products_prices[product.id],
-            "float_round": float_round,
-            "shop_path": SHOP_PATH,
-            "product_query_params": product_query_params,
-            "grouped_attributes_values": grouped_attributes_values,
-            "previewed_attribute_values": lazy(
-                lambda: products._get_previewed_attribute_values(
-                    category, product_query_params
-                ),
-            ),
-        }
-        if filter_by_price_enabled:
-            values["min_price"] = min_price or available_min_price
-            values["max_price"] = max_price or available_max_price
-            values["available_min_price"] = float_round(available_min_price, 2)
-            values["available_max_price"] = float_round(available_max_price, 2)
-        if filter_by_tags_enabled:
-            values.update({"all_tags": all_tags, "tags": tags})
-        if category:
-            values["main_object"] = category
-        values.update(self._get_additional_shop_values(values, **post))
-        return request.render("website_sale.products", values)
-
-    @staticmethod
-    def _get_additional_attribute_value_list(attribute_values):
-        """Parses a list of attribute value query params, and returns a list
-        grouping attribute values by attribute id.
-
-        :param list(str) attribute_values: The list of attribute value
-        query parameters to parse.
-        :return: A list grouping attribute values by attribute id.
-        :rtype: list([int, list(int)])
-        """
-        attribute_value_pairs = [
-            value.split("-", maxsplit=1)
-            for value in attribute_values
-            if value and value[0] != "["
-        ]
-        return [[int(pair[0]), pair[1]] for pair in attribute_value_pairs]
+        if additional_attrib_list:
+            result["additional_attribute_values"] = additional_attrib_list
+        return result
 
     def _get_search_options(
         self,
@@ -402,25 +70,26 @@ class WebsiteSale(main.WebsiteSale):
             conversion_rate=conversion_rate,
             **post,
         )
-        if post.get("additional_attribute_values", False):
-            values["additional_attribute_values"] = post["additional_attribute_values"]
+        additional_attrib_values = self._parse_additional_attrib_values()
+        if additional_attrib_values:
+            values["additional_attribute_values"] = additional_attrib_values
         return values
 
     def _get_additional_shop_values(self, values, **kwargs):
-        # Can be used to search & filter products depending on their custom attributes
         """Hook to update values used for rendering website_sale.products template"""
         extra_values = super()._get_additional_shop_values(values, **kwargs)
-        extra_values.update(
-            {
-                "additional_attributes": [],
-            }
+
+        additional_attrib_values = self._parse_additional_attrib_values()
+        additional_attrib_set = set(
+            (item[0], item[1]) for item in additional_attrib_values
         )
+        extra_values["additional_attrib_set"] = additional_attrib_set
+        extra_values["additional_attributes"] = []
+
         search_product = values.get("search_product")
         all_additional_attributes = request.env["attribute.attribute"].sudo()
         product_attrs_map = {}
         if search_product:
-            # loop to get all attributes that only have values
-            # that can be displayed in e-commerce website
             for product in search_product:
                 additional_attributes = product.sudo().get_extra_attributes()
                 if additional_attributes:
@@ -428,7 +97,6 @@ class WebsiteSale(main.WebsiteSale):
                     all_additional_attributes |= additional_attributes
 
             if all_additional_attributes:
-                # loop to get all assigned attribute values for all related products
                 for attribute in all_additional_attributes:
                     all_attribute_values = set()
                     value_counts = {}
@@ -440,9 +108,6 @@ class WebsiteSale(main.WebsiteSale):
                             attribute
                         )
                         if attribute_values:
-                            # To avoid repetition of select options in the template
-                            # We make sure if the attribute_values is a single value or
-                            # if it is a recordset we loop through it
                             if (
                                 isinstance(attribute_values, BaseModel)
                                 and len(attribute_values) > 1
@@ -471,66 +136,21 @@ class WebsiteSale(main.WebsiteSale):
 
         return extra_values
 
-    def _prepare_product_values(self, product, category, **kwargs):
-        vals = super()._prepare_product_values(product, category, **kwargs)
-
-        last_attributes_search = request.session.get("attribute_values", [])
-        last_additional_attributes_search = request.session.get(
-            "additional_attribute_values", []
-        )
-        if last_attributes_search and last_additional_attributes_search:
-            keep = QueryURL(
-                self._get_shop_path(category),
-                attribute_values=last_attributes_search,
-                additional_attribute_values=last_additional_attributes_search,
-            )
-            vals["keep"] = keep
-        elif last_additional_attributes_search:
-            keep = QueryURL(
-                self._get_shop_path(category),
-                additional_attribute_values=last_additional_attributes_search,
-            )
-            vals["keep"] = keep
-
-        additional_attributes = product.sudo().get_extra_attributes()
-        if additional_attributes:
-            vals.update({"additional_attributes": []})
-            for attribute in additional_attributes:
-                attribute_values = product.sudo().get_extra_attribute_values(attribute)
-                vals["additional_attributes"].append(
-                    {"attribute": attribute, "attribute_values": attribute_values}
-                )
-        return vals
-
-    def _shop_get_query_url_kwargs(
-        self, search, min_price, max_price, order=None, tags=None, **kwargs
-    ):
-        res = super()._shop_get_query_url_kwargs(
-            search, min_price, max_price, order, tags, **kwargs
-        )
-        additional_attribute_values = request.session.get(
-            "additional_attribute_values", []
-        )
-        res["additional_attribute_values"] = additional_attribute_values
-        return res
-
     def _get_shop_domain(self, search, category, attribute_value_dict, **kwargs):
         """Extend shop domain with additional attribute filters."""
         domain = super()._get_shop_domain(
             search, category, attribute_value_dict, **kwargs
         )
 
-        additional_attribute_values = request.session.get(
-            "additional_attribute_values", []
-        )
-        additional_range_filters = request.session.get("additional_range_filters", {})
+        additional_attrib_values = self._parse_additional_attrib_values()
+        additional_range_filters = self._parse_additional_range_filters()
 
         additional_conditions = []
         additional_conditions.extend(
             self._build_range_filter_conditions(additional_range_filters)
         )
         additional_conditions.extend(
-            self._build_value_filter_conditions(additional_attribute_values)
+            self._build_value_filter_conditions(additional_attrib_values)
         )
 
         if additional_conditions:
@@ -547,9 +167,9 @@ class WebsiteSale(main.WebsiteSale):
                 continue
             field_name = attribute.name
             if "min" in range_vals:
-                conditions.append(Domain(field_name, ">=", range_vals["min"]))
+                conditions.append((field_name, ">=", range_vals["min"]))
             if "max" in range_vals:
-                conditions.append(Domain(field_name, "<=", range_vals["max"]))
+                conditions.append((field_name, "<=", range_vals["max"]))
         return conditions
 
     def _build_value_filter_conditions(self, attrib_values):
@@ -560,7 +180,6 @@ class WebsiteSale(main.WebsiteSale):
         conditions = []
         Attribute = request.env["attribute.attribute"].sudo()
 
-        # Group values by attribute for multi-select support
         attr_values_grouped = {}
         for attr_id, attr_value in attrib_values:
             attr_values_grouped.setdefault(attr_id, []).append(attr_value)
@@ -573,7 +192,6 @@ class WebsiteSale(main.WebsiteSale):
             field_name = attribute.name
             attr_type = attribute.attribute_type
 
-            # Multi-select: OR within same attribute
             if len(values) > 1 and attribute.e_com_multi_select:
                 or_conds = [
                     c
@@ -595,23 +213,36 @@ class WebsiteSale(main.WebsiteSale):
         """Build a single domain condition for an attribute value."""
         if attr_type == "boolean":
             value = attr_value.lower() == "true"
-            return Domain(field_name, "=", value)
+            return [(field_name, "=", value)]
         elif attr_type in ("select", "multiselect"):
             try:
                 option_id = int(attr_value)
-                return Domain(field_name, "=", option_id)
+                return [(field_name, "=", option_id)]
             except (ValueError, TypeError):
                 return None
         elif attr_type == "integer":
             try:
-                return Domain(field_name, "=", int(attr_value))
+                value = int(attr_value)
+                return [(field_name, "=", value)]
             except (ValueError, TypeError):
                 return None
         elif attr_type == "float":
             try:
-                return Domain(field_name, "=", float(attr_value))
+                value = float(attr_value)
+                return [(field_name, "=", value)]
             except (ValueError, TypeError):
                 return None
         else:
-            # char, text, date, datetime - use exact match
-            return Domain(field_name, "=", attr_value)
+            return [(field_name, "=", attr_value)]
+
+    def _prepare_product_values(self, product, category, **kwargs):
+        vals = super()._prepare_product_values(product, category, **kwargs)
+        vals["additional_attributes"] = []
+        extra_attributes = product.sudo().get_extra_attributes()
+        for attribute in extra_attributes:
+            attribute_values = product.sudo().get_extra_attribute_values(attribute)
+            if attribute_values:
+                vals["additional_attributes"].append(
+                    {"attribute": attribute, "attribute_values": attribute_values}
+                )
+        return vals

--- a/website_attribute_set/controllers/main.py
+++ b/website_attribute_set/controllers/main.py
@@ -415,11 +415,11 @@ class WebsiteSale(main.WebsiteSale):
                 "additional_attributes": [],
             }
         )
-        if values.get("products"):
-            search_product = values.get("search_product")
-            all_additional_attributes = request.env["attribute.attribute"].sudo()
-            product_attrs_map = {}
-            # loop to get all attributes that only haves values
+        search_product = values.get("search_product")
+        all_additional_attributes = request.env["attribute.attribute"].sudo()
+        product_attrs_map = {}
+        if search_product:
+            # loop to get all attributes that only have values
             # that can be displayed in e-commerce website
             for product in search_product:
                 additional_attributes = product.sudo().get_extra_attributes()

--- a/website_attribute_set/migrations/19.0.1.0.1/pre-migrate.py
+++ b/website_attribute_set/migrations/19.0.1.0.1/pre-migrate.py
@@ -1,0 +1,25 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # custom_specifications_table changed from an inherited view
+    # (inherit_id=website_sale_comparison.specifications_table) to a primary
+    # standalone template. Remove the stale inherit_id so the upgrade can
+    # reload the view without a "cannot be located in parent view" error.
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE ir_ui_view
+        SET inherit_id = NULL,
+            mode = 'primary'
+        WHERE id = (
+            SELECT res_id
+            FROM ir_model_data
+            WHERE module = 'website_attribute_set'
+              AND name = 'custom_specifications_table'
+              AND model = 'ir.ui.view'
+        )
+          AND inherit_id IS NOT NULL
+        """,
+    )

--- a/website_attribute_set/models/attribute_attribute.py
+++ b/website_attribute_set/models/attribute_attribute.py
@@ -14,12 +14,22 @@ class AttributeAttribute(models.Model):
     e_com_visibility = fields.Boolean(
         string="E-Commerce Visibility",
         default=False,
-        help="""If selected the attribute will be shown in e-commerce website app.""",
+        help="""If selected, the attribute will be shown in e-commerce website app.""",
+    )
+    e_com_filter = fields.Boolean(
+        default=False,
+        help="""If selected, the attribute will be shown as a filter
+         in the e-commerce shop sidebar.""",
+    )
+    e_com_specification = fields.Boolean(
+        default=False,
+        help="""If selected, the attribute will be shown as specification
+             in e-commerce website app product view.""",
     )
     e_com_searchable = fields.Boolean(
         string="E-Commerce Searchable",
         default=False,
-        help="""If selected the attribute will be included in e-commerce search.
+        help="""If selected, the attribute will be included in e-commerce search.
         Disable for large text fields to improve search performance.""",
     )
     e_com_range_filter = fields.Boolean(
@@ -39,6 +49,81 @@ class AttributeAttribute(models.Model):
         default=False,
         help="""Show the number of matching products next to each filter option.""",
     )
+
+    @api.constrains("e_com_filter")
+    def _check_e_com_filter(self):
+        for rec in self:
+            if rec.e_com_filter and not rec.e_com_visibility:
+                raise ValidationError(
+                    self.env._(
+                        "Cannot use attribute as filter "
+                        "if it doesn't have E-Commerce Visibility enabled."
+                    )
+                )
+
+    @api.constrains("e_com_specification")
+    def _check_e_com_specification(self):
+        for rec in self:
+            if rec.e_com_specification and not rec.e_com_visibility:
+                raise ValidationError(
+                    self.env._(
+                        "Cannot use attribute as specification "
+                        "if it doesn't have E-Commerce Visibility enabled."
+                    )
+                )
+
+    @api.constrains("e_com_searchable")
+    def _check_e_com_searchable(self):
+        for rec in self:
+            if rec.e_com_searchable and not rec.e_com_visibility:
+                raise ValidationError(
+                    self.env._(
+                        "Cannot make attribute searchable "
+                        "if it doesn't have E-Commerce Visibility enabled."
+                    )
+                )
+
+    @api.constrains("e_com_range_filter", "e_com_multi_select", "e_com_show_count")
+    def _check_filter_options(self):
+        for rec in self:
+            if (
+                rec.e_com_range_filter or rec.e_com_multi_select or rec.e_com_show_count
+            ) and not rec.e_com_filter:
+                raise ValidationError(
+                    self.env._(
+                        "E-Commerce Range Filter, Multi-Select and Show Count "
+                        "require the attribute to be enabled as a filter."
+                    )
+                )
+
+    @api.onchange("e_com_visibility")
+    def onchange_e_com_visibility(self):
+        for rec in self:
+            if rec.e_com_visibility:
+                rec.write({"e_com_filter": True, "e_com_specification": True})
+            else:
+                rec.write(
+                    {
+                        "e_com_filter": False,
+                        "e_com_specification": False,
+                        "e_com_searchable": False,
+                        "e_com_range_filter": False,
+                        "e_com_multi_select": False,
+                        "e_com_show_count": False,
+                    }
+                )
+
+    @api.onchange("e_com_filter")
+    def onchange_e_com_filter(self):
+        for rec in self:
+            if not rec.e_com_filter:
+                rec.write(
+                    {
+                        "e_com_range_filter": False,
+                        "e_com_multi_select": False,
+                        "e_com_show_count": False,
+                    }
+                )
 
     @api.constrains("domain")
     def _validate_domain(self):

--- a/website_attribute_set/models/attribute_set_owner.py
+++ b/website_attribute_set/models/attribute_set_owner.py
@@ -11,7 +11,12 @@ class AttributeSetOwnerMixin(models.AbstractModel):
     _inherit = "attribute.set.owner.mixin"
 
     def get_extra_attributes(self):
-        """Get extra product's attribute for e-commerce website."""
+        """Get extra product's attribute for e-commerce website.
+
+        Walks the attribute set hierarchy so that a product assigned to a
+        child set also exposes the attributes inherited from any ancestor
+        set, matching the behaviour of the backend form view.
+        """
         self.ensure_one()
         domain = [
             ("model", "=", self._name),
@@ -22,7 +27,7 @@ class AttributeSetOwnerMixin(models.AbstractModel):
             attributes = attribute.search(domain)
             attribute_set_id = self.attribute_set_id
             filtered_attributes = attributes.filtered(
-                lambda rec: attribute_set_id.id in rec.attribute_set_ids.ids
+                lambda rec: attribute_set_id.id in rec._get_all_set_ids()
                 and rec.e_com_visibility
             )
             return filtered_attributes

--- a/website_attribute_set/models/product_product.py
+++ b/website_attribute_set/models/product_product.py
@@ -24,6 +24,7 @@ class ProductProduct(models.Model):
         attributes = self.env["attribute.attribute"]
         for product in self:
             attributes |= product.product_tmpl_id.get_extra_attributes()
+        attributes = attributes.filtered(lambda a: a.e_com_specification)
         groups = OrderedDict(
             [(group, OrderedDict()) for group in attributes.attribute_group_id.sorted()]
         )

--- a/website_attribute_set/models/product_template.py
+++ b/website_attribute_set/models/product_template.py
@@ -36,7 +36,7 @@ class ProductTemplate(models.Model):
         groups = OrderedDict(
             [(group, OrderedDict()) for group in attributes.attribute_group_id.sorted()]
         )
-        for attribute in attributes:
+        for attribute in attributes.filtered(lambda a: a.e_com_specification):
             values = self.get_extra_attribute_values(attribute)
             if isinstance(values, models.BaseModel):
                 if len(values) == 1:

--- a/website_attribute_set/static/src/interactions/website_sale.esm.js
+++ b/website_attribute_set/static/src/interactions/website_sale.esm.js
@@ -23,7 +23,7 @@ patch(WebsiteSale.prototype, {
         const tags = new Set();
         for (const filter of filters) {
             if (filter.value) {
-                if (filter.name === "additional_attribute_value") {
+                if (filter.name === "additional_attribute_values") {
                     // Group attribute value ids by attribute id.
                     const firstDash = filter.value.indexOf("-");
                     const [attributeId, attributeValueId] = [

--- a/website_attribute_set/tests/__init__.py
+++ b/website_attribute_set/tests/__init__.py
@@ -4,3 +4,4 @@
 
 from . import test_website_attr_set
 from . import test_controller
+from . import test_shop_ui

--- a/website_attribute_set/tests/test_controller.py
+++ b/website_attribute_set/tests/test_controller.py
@@ -42,6 +42,8 @@ class TestWebsiteAttributeController(HttpCase):
                 "attribute_set_ids": [(4, cls.attr_set.id)],
                 "model_id": cls.product_model.id,
                 "e_com_visibility": True,
+                "e_com_filter": True,
+                "e_com_specification": True,
             }
         )
 
@@ -56,6 +58,8 @@ class TestWebsiteAttributeController(HttpCase):
                 "attribute_set_ids": [(4, cls.attr_set.id)],
                 "model_id": cls.product_model.id,
                 "e_com_visibility": True,
+                "e_com_filter": True,
+                "e_com_specification": True,
             }
         )
 
@@ -71,6 +75,8 @@ class TestWebsiteAttributeController(HttpCase):
                 "attribute_set_ids": [(4, cls.attr_set.id)],
                 "model_id": cls.product_model.id,
                 "e_com_visibility": True,
+                "e_com_filter": True,
+                "e_com_specification": True,
             }
         )
 
@@ -93,6 +99,8 @@ class TestWebsiteAttributeController(HttpCase):
                 "attribute_set_ids": [(4, cls.attr_set.id)],
                 "model_id": cls.product_model.id,
                 "e_com_visibility": True,
+                "e_com_filter": True,
+                "e_com_specification": True,
             }
         )
 

--- a/website_attribute_set/tests/test_shop_ui.py
+++ b/website_attribute_set/tests/test_shop_ui.py
@@ -1,0 +1,383 @@
+"""UI-level tests for the website_attribute_set shop features.
+
+These tests verify that the e_com_filter / e_com_specification fields actually
+control what appears in the rendered HTML: filter panel and product page
+specifications table.
+"""
+
+from lxml import etree
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestShopFilterUI(HttpCase):
+    """Verify that additional attribute filters render correctly in the shop."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website = cls.env.ref("website.default_website")
+        cls.product_model = cls.env.ref("product.model_product_template")
+
+        cls.attr_group = cls.env["attribute.group"].create(
+            {
+                "name": "UI Test Group",
+                "model_id": cls.product_model.id,
+                "sequence": 1,
+            }
+        )
+        cls.attr_set = cls.env["attribute.set"].create(
+            {
+                "name": "UI Test Attribute Set",
+                "model_id": cls.product_model.id,
+            }
+        )
+
+        # Attribute visible as filter AND specification
+        cls.attr_color = cls.env["attribute.attribute"].create(
+            {
+                "nature": "custom",
+                "field_description": "UI Test Color",
+                "name": "x_uitest_color",
+                "attribute_type": "char",
+                "attribute_group_id": cls.attr_group.id,
+                "attribute_set_ids": [(4, cls.attr_set.id)],
+                "model_id": cls.product_model.id,
+                "e_com_visibility": True,
+                "e_com_filter": True,
+                "e_com_specification": True,
+            }
+        )
+
+        # Attribute visible as specification only (NOT as filter)
+        cls.attr_weight = cls.env["attribute.attribute"].create(
+            {
+                "nature": "custom",
+                "field_description": "UI Test Weight",
+                "name": "x_uitest_weight",
+                "attribute_type": "char",
+                "attribute_group_id": cls.attr_group.id,
+                "attribute_set_ids": [(4, cls.attr_set.id)],
+                "model_id": cls.product_model.id,
+                "e_com_visibility": True,
+                "e_com_filter": False,
+                "e_com_specification": True,
+            }
+        )
+
+        # Attribute visible as filter only (NOT as specification)
+        cls.attr_origin = cls.env["attribute.attribute"].create(
+            {
+                "nature": "custom",
+                "field_description": "UI Test Origin",
+                "name": "x_uitest_origin",
+                "attribute_type": "char",
+                "attribute_group_id": cls.attr_group.id,
+                "attribute_set_ids": [(4, cls.attr_set.id)],
+                "model_id": cls.product_model.id,
+                "e_com_visibility": True,
+                "e_com_filter": True,
+                "e_com_specification": False,
+            }
+        )
+
+        # Boolean attribute as filter
+        cls.attr_available = cls.env["attribute.attribute"].create(
+            {
+                "nature": "custom",
+                "field_description": "UI Test Available",
+                "name": "x_uitest_available",
+                "attribute_type": "boolean",
+                "attribute_group_id": cls.attr_group.id,
+                "attribute_set_ids": [(4, cls.attr_set.id)],
+                "model_id": cls.product_model.id,
+                "e_com_visibility": True,
+                "e_com_filter": True,
+                "e_com_specification": True,
+            }
+        )
+
+        # Create products
+        cls.product_a = cls.env["product.template"].create(
+            {
+                "name": "UI Test Product Alpha",
+                "is_published": True,
+                "website_id": cls.website.id,
+                "attribute_set_id": cls.attr_set.id,
+                "x_uitest_color": "Red",
+                "x_uitest_weight": "1.5 kg",
+                "x_uitest_origin": "Spain",
+                "x_uitest_available": True,
+            }
+        )
+        cls.product_b = cls.env["product.template"].create(
+            {
+                "name": "UI Test Product Beta",
+                "is_published": True,
+                "website_id": cls.website.id,
+                "attribute_set_id": cls.attr_set.id,
+                "x_uitest_color": "Blue",
+                "x_uitest_weight": "2.0 kg",
+                "x_uitest_origin": "France",
+                "x_uitest_available": False,
+            }
+        )
+
+    def _get_html(self, url):
+        """Fetch a page and return parsed HTML tree."""
+        self.authenticate("admin", "admin")
+        response = self.url_open(url, timeout=30)
+        self.assertEqual(response.status_code, 200)
+        return etree.fromstring(response.content, etree.HTMLParser())
+
+    def _get_filter_headings(self, tree):
+        """Extract additional attribute filter heading texts from the shop page."""
+        # Desktop: id="o_products_additional_attributes_{id}", heading replaced by
+        #          div.accordion-header.h6 > button > b
+        # Mobile:  id="o_wsale_offcanvas_additional_attribute_{id}", heading
+        #          in h2 > button > b
+        headings = tree.xpath(
+            "//div[starts-with(@id, 'o_products_additional_attributes_')"
+            " or starts-with(@id, 'o_wsale_offcanvas_additional_attribute_')]"
+            "/preceding-sibling::*//b"
+        )
+        return [
+            etree.tostring(h, encoding="unicode", method="text").strip()
+            for h in headings
+        ]
+
+    def _get_product_names(self, tree):
+        """Extract product names from the shop product grid."""
+        name_texts = tree.xpath("//div[contains(@class, 'oe_product')]//h6//text()")
+        return [n.strip() for n in name_texts if n.strip()]
+
+    # ── Shop filter panel tests ──
+
+    def test_filter_attribute_appears_in_shop(self):
+        """Attributes with e_com_filter=True must appear in the shop filter panel."""
+        tree = self._get_html("/shop")
+        filter_headings = self._get_filter_headings(tree)
+        self.assertIn(
+            "UI Test Color",
+            filter_headings,
+            "Attribute with e_com_filter=True should appear in the shop filter panel",
+        )
+        self.assertIn(
+            "UI Test Origin",
+            filter_headings,
+            "Attribute with e_com_filter=True should appear in the shop filter panel",
+        )
+
+    def test_non_filter_attribute_hidden_in_shop(self):
+        """Attributes with e_com_filter=False must NOT appear in the filter panel."""
+        tree = self._get_html("/shop")
+        filter_headings = self._get_filter_headings(tree)
+        self.assertNotIn(
+            "UI Test Weight",
+            filter_headings,
+            "Attribute with e_com_filter=False should NOT appear in the filter panel",
+        )
+
+    def test_boolean_filter_renders_checkboxes(self):
+        """Boolean attributes should render as checkboxes with Yes/No labels."""
+        tree = self._get_html("/shop")
+        boolean_inputs = tree.xpath(
+            f"//input[@name='additional_attribute_values']"
+            f"[contains(@value, '{self.attr_available.id}-')]"
+        )
+        self.assertTrue(
+            boolean_inputs,
+            "Boolean filter attribute should render checkbox inputs",
+        )
+
+    def test_char_filter_renders_select(self):
+        """Char attributes should render as a <select> dropdown."""
+        tree = self._get_html("/shop")
+        selects = tree.xpath(
+            f"//div[@id='o_products_additional_attributes_{self.attr_color.id}']"
+            f"//select[@name='additional_attribute_values']"
+        )
+        self.assertTrue(
+            selects,
+            "Char filter attribute should render as a <select> dropdown",
+        )
+        # Check that the values appear as options
+        options = selects[0].xpath(".//option[text()]")
+        option_texts = [
+            etree.tostring(opt, encoding="unicode", method="text").strip()
+            for opt in options
+        ]
+        self.assertIn("Red", option_texts)
+        self.assertIn("Blue", option_texts)
+
+    # ── Filter application tests ──
+
+    def test_boolean_filter_filters_products(self):
+        """Applying a boolean filter should hide non-matching products."""
+        self.authenticate("admin", "admin")
+        attr_id = self.attr_available.id
+        response = self.url_open(
+            f"/shop?additional_attribute_values={attr_id}-True", timeout=30
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.text
+        self.assertIn("UI Test Product Alpha", content)
+        self.assertNotIn(
+            "UI Test Product Beta",
+            content,
+            "Product with x_uitest_available=False should be filtered out",
+        )
+
+    def test_char_filter_filters_products(self):
+        """Applying a char filter should show only matching products."""
+        self.authenticate("admin", "admin")
+        attr_id = self.attr_color.id
+        response = self.url_open(
+            f"/shop?additional_attribute_values={attr_id}-Red", timeout=30
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.text
+        self.assertIn("UI Test Product Alpha", content)
+        self.assertNotIn(
+            "UI Test Product Beta",
+            content,
+            "Product with x_uitest_color=Blue should be filtered out "
+            "when filtering by Red",
+        )
+
+
+@tagged("post_install", "-at_install")
+class TestProductPageUI(HttpCase):
+    """Verify that specifications render correctly on the product page."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website = cls.env.ref("website.default_website")
+        cls.product_model = cls.env.ref("product.model_product_template")
+
+        cls.attr_group = cls.env["attribute.group"].create(
+            {
+                "name": "UI Spec Test Group",
+                "model_id": cls.product_model.id,
+                "sequence": 1,
+            }
+        )
+        cls.attr_set = cls.env["attribute.set"].create(
+            {
+                "name": "UI Spec Test Attribute Set",
+                "model_id": cls.product_model.id,
+            }
+        )
+
+        # Specification-visible attribute
+        cls.attr_material = cls.env["attribute.attribute"].create(
+            {
+                "nature": "custom",
+                "field_description": "UI Spec Material",
+                "name": "x_uispec_material",
+                "attribute_type": "char",
+                "attribute_group_id": cls.attr_group.id,
+                "attribute_set_ids": [(4, cls.attr_set.id)],
+                "model_id": cls.product_model.id,
+                "e_com_visibility": True,
+                "e_com_filter": False,
+                "e_com_specification": True,
+            }
+        )
+
+        # Filter-only attribute (should NOT appear in specifications)
+        cls.attr_sku = cls.env["attribute.attribute"].create(
+            {
+                "nature": "custom",
+                "field_description": "UI Spec SKU Code",
+                "name": "x_uispec_sku",
+                "attribute_type": "char",
+                "attribute_group_id": cls.attr_group.id,
+                "attribute_set_ids": [(4, cls.attr_set.id)],
+                "model_id": cls.product_model.id,
+                "e_com_visibility": True,
+                "e_com_filter": True,
+                "e_com_specification": False,
+            }
+        )
+
+        cls.product = cls.env["product.template"].create(
+            {
+                "name": "UI Spec Test Product",
+                "is_published": True,
+                "website_id": cls.website.id,
+                "attribute_set_id": cls.attr_set.id,
+                "x_uispec_material": "Stainless Steel",
+                "x_uispec_sku": "SKU-12345",
+            }
+        )
+
+    def _get_html(self, url):
+        self.authenticate("admin", "admin")
+        response = self.url_open(url, timeout=30)
+        self.assertEqual(response.status_code, 200)
+        return etree.fromstring(response.content, etree.HTMLParser())
+
+    def test_specification_attribute_appears_on_product_page(self):
+        """Attributes with e_com_specification=True should appear in the
+        specifications table on the product page."""
+        tree = self._get_html(f"/shop/{self.product.id}")
+        spec_items = tree.xpath("//li[contains(@class, 'variant_attribute')]")
+        self.assertTrue(
+            spec_items,
+            "Specifications section should be present on the product page",
+        )
+        spec_text = "".join(
+            etree.tostring(li, encoding="unicode", method="text") for li in spec_items
+        )
+        self.assertIn(
+            "Stainless Steel",
+            spec_text,
+            "Specification attribute value should appear on the product page",
+        )
+        self.assertIn(
+            "UI Spec Material",
+            spec_text,
+            "Specification attribute label should appear on the product page",
+        )
+
+    def test_non_specification_attribute_hidden_on_product_page(self):
+        """Attributes with e_com_specification=False should NOT appear
+        in the specifications table."""
+        tree = self._get_html(f"/shop/{self.product.id}")
+        spec_items = tree.xpath("//li[contains(@class, 'variant_attribute')]")
+        if spec_items:
+            spec_text = "".join(
+                etree.tostring(li, encoding="unicode", method="text")
+                for li in spec_items
+            )
+            self.assertNotIn(
+                "SKU-12345",
+                spec_text,
+                "Attribute with e_com_specification=False should NOT appear "
+                "in the specifications table",
+            )
+            self.assertNotIn(
+                "UI Spec SKU Code",
+                spec_text,
+                "Attribute label with e_com_specification=False should NOT appear "
+                "in the specifications table",
+            )
+
+    def test_product_without_attributes_has_no_spec_section(self):
+        """Products without attribute sets should not show a specs section."""
+        product = self.env["product.template"].create(
+            {
+                "name": "Plain Product No Specs",
+                "is_published": True,
+                "website_id": self.website.id,
+            }
+        )
+        tree = self._get_html(f"/shop/{product.id}")
+        spec_items = tree.xpath("//li[contains(@class, 'variant_attribute')]")
+        self.assertFalse(
+            spec_items,
+            "Product without attribute set should not have a specifications section",
+        )

--- a/website_attribute_set/tests/test_website_attr_set.py
+++ b/website_attribute_set/tests/test_website_attr_set.py
@@ -146,11 +146,13 @@ class TestAttributeSetSearchable(BuildViewCase):
         self.product_1.x_processor = test_option
         self.product_1.write({"x_technical_description": "Fast processor"})
         self.attr_1.write({"e_com_visibility": True})
+        self.attr_1.onchange_e_com_visibility()
         extra_attrs = self.product_1.get_extra_attributes()
         self.assertTrue(
             len(extra_attrs) == 1 and extra_attrs.mapped("name") == ["x_processor"]
         )
         self.attr_2.write({"e_com_visibility": True})
+        self.attr_2.onchange_e_com_visibility()
         extra_attrs = self.product_1.get_extra_attributes()
         self.assertTrue(
             len(extra_attrs) == 2
@@ -164,18 +166,21 @@ class TestAttributeSetSearchable(BuildViewCase):
         # attributes are searchable in e-com but
         # if they are select or multi-select then
         # they need relation_model_id value
-        self.attr_1.write({"e_com_searchable": True})
+        self.attr_1.write({"e_com_visibility": True, "e_com_searchable": True})
+        self.attr_1.onchange_e_com_visibility()
         domain = search_extra(self.env, "Fast processor")
         self.assertEqual(list(domain), [(0, "=", 1)])
         # attributes are searchable in e-com
-        self.attr_2.write({"e_com_searchable": True})
+        self.attr_2.write({"e_com_visibility": True, "e_com_searchable": True})
+        self.attr_2.onchange_e_com_visibility()
         domain = search_extra(self.env, "Fast processor")
         self.assertEqual(
             list(domain), [("x_technical_description", "ilike", "Fast processor")]
         )
         # select, multi-select attributes are searchable in e-com as
         # they have relation_model_id value
-        self.attr_3.write({"e_com_searchable": True})
+        self.attr_3.write({"e_com_visibility": True, "e_com_searchable": True})
+        self.attr_3.onchange_e_com_visibility()
         domain = search_extra(self.env, "Fast processor")
         self.assertEqual(
             list(domain),
@@ -190,6 +195,7 @@ class TestAttributeSetSearchable(BuildViewCase):
         """Test that e_com_searchable controls search, not e_com_visibility."""
         # Set attribute visible but NOT searchable
         self.attr_2.write({"e_com_visibility": True, "e_com_searchable": False})
+        self.attr_2.onchange_e_com_visibility()
         domain = search_extra(self.env, "Fast processor")
         # Should NOT include this attribute in search
         self.assertEqual(list(domain), [(0, "=", 1)])
@@ -242,8 +248,10 @@ class TestAttributeSetSearchable(BuildViewCase):
         for i in results[1]:
             self.assertEqual(i["count"], 0)
         # custom attributes appear in e-com search if we set searchable
-        self.attr_2.write({"e_com_searchable": True})
-        self.attr_3.write({"e_com_searchable": True})
+        self.attr_2.write({"e_com_visibility": True, "e_com_searchable": True})
+        self.attr_2.onchange_e_com_visibility()
+        self.attr_3.write({"e_com_visibility": True, "e_com_searchable": True})
+        self.attr_3.onchange_e_com_visibility()
         results = (
             self.env["website"]
             .browse(1)
@@ -285,6 +293,7 @@ class TestAttributeSetSearchable(BuildViewCase):
         # ordered dict exists if products are visible in e-com
         self.product_1.write({"x_technical_description": "Fast processor"})
         self.attr_2.write({"e_com_visibility": True})
+        self.attr_2.onchange_e_com_visibility()
         groups = product_1._prepare_additional_attributes_for_display()
         self.assertTrue(self.group_1 in groups)
         self.assertTrue(self.attr_2 in groups[self.group_1])
@@ -307,11 +316,83 @@ class TestAttributeSetSearchable(BuildViewCase):
         # Attribute with a value and e_com_visibility appears in groups
         self.product_1.write({"x_technical_description": "Fast processor"})
         self.attr_2.write({"e_com_visibility": True})
+        self.attr_2.onchange_e_com_visibility()
         groups = self.product_1._prepare_simple_additional_attributes_for_display()
         self.assertIn(self.group_1, groups)
         self.assertIn(self.attr_2, groups[self.group_1])
         self.assertEqual(groups[self.group_1][self.attr_2], "Fast processor")
         # Attribute with no value is excluded from groups
         self.attr_1.write({"e_com_visibility": True})
+        self.attr_1.onchange_e_com_visibility()
         groups = self.product_1._prepare_simple_additional_attributes_for_display()
         self.assertNotIn(self.attr_1, groups[self.group_1])
+
+    def test_constraints_filter_options_require_e_com_filter(self):
+        # e_com_range_filter, e_com_multi_select, e_com_show_count require e_com_filter
+        self.attr_2.write({"e_com_visibility": True, "e_com_filter": True})
+        self.attr_2.onchange_e_com_visibility()
+        with self.assertRaises(ValidationError):
+            self.attr_2.write({"e_com_filter": False, "e_com_range_filter": True})
+        with self.assertRaises(ValidationError):
+            self.attr_2.write({"e_com_filter": False, "e_com_multi_select": True})
+        with self.assertRaises(ValidationError):
+            self.attr_2.write({"e_com_filter": False, "e_com_show_count": True})
+        # Setting them with e_com_filter=True is allowed
+        self.attr_2.write(
+            {
+                "e_com_filter": True,
+                "e_com_range_filter": True,
+                "e_com_multi_select": True,
+                "e_com_show_count": True,
+            }
+        )
+
+    def test_constraint_e_com_searchable_requires_visibility(self):
+        # e_com_searchable requires e_com_visibility
+        with self.assertRaises(ValidationError):
+            self.attr_2.write({"e_com_visibility": False, "e_com_searchable": True})
+        self.attr_2.write({"e_com_visibility": True, "e_com_searchable": True})
+        self.attr_2.onchange_e_com_visibility()
+
+    def test_onchange_e_com_visibility_clears_dependents(self):
+        # Enable everything
+        self.attr_2.write(
+            {
+                "e_com_visibility": True,
+                "e_com_filter": True,
+                "e_com_specification": True,
+                "e_com_searchable": True,
+                "e_com_range_filter": True,
+                "e_com_multi_select": True,
+                "e_com_show_count": True,
+            }
+        )
+        self.attr_2.onchange_e_com_visibility()
+        # Turning off visibility clears all dependent fields
+        self.attr_2.write({"e_com_visibility": False})
+        self.attr_2.onchange_e_com_visibility()
+        self.assertFalse(self.attr_2.e_com_filter)
+        self.assertFalse(self.attr_2.e_com_specification)
+        self.assertFalse(self.attr_2.e_com_searchable)
+        self.assertFalse(self.attr_2.e_com_range_filter)
+        self.assertFalse(self.attr_2.e_com_multi_select)
+        self.assertFalse(self.attr_2.e_com_show_count)
+
+    def test_onchange_e_com_filter_clears_filter_options(self):
+        # Enable filter options
+        self.attr_2.write(
+            {
+                "e_com_visibility": True,
+                "e_com_filter": True,
+                "e_com_range_filter": True,
+                "e_com_multi_select": True,
+                "e_com_show_count": True,
+            }
+        )
+        self.attr_2.onchange_e_com_visibility()
+        # Turning off e_com_filter clears filter-specific options
+        self.attr_2.write({"e_com_filter": False})
+        self.attr_2.onchange_e_com_filter()
+        self.assertFalse(self.attr_2.e_com_range_filter)
+        self.assertFalse(self.attr_2.e_com_multi_select)
+        self.assertFalse(self.attr_2.e_com_show_count)

--- a/website_attribute_set/views/attribute_attribute_view.xml
+++ b/website_attribute_set/views/attribute_attribute_view.xml
@@ -6,19 +6,26 @@
         <field name="inherit_id" ref="attribute_set.attribute_attribute_form_view" />
         <field name="arch" type="xml">
             <data>
-                <xpath expr="//field[@name='serialized']" position="after">
-                    <field name="e_com_visibility" />
-                    <group invisible="not e_com_visibility" col="2">
-                        <field name="e_com_searchable" />
-                        <field
-                            name="e_com_range_filter"
-                            invisible="attribute_type not in ('integer', 'float')"
-                        />
-                        <field
-                            name="e_com_multi_select"
-                            invisible="attribute_type not in ('select', 'multiselect')"
-                        />
-                        <field name="e_com_show_count" />
+                <xpath expr="//notebook" position="before">
+                    <separator string="E-Commerce" />
+                    <group>
+                        <group>
+                            <field name="e_com_visibility" />
+                        </group>
+                        <group invisible="not e_com_visibility">
+                            <field name="e_com_filter" />
+                            <field name="e_com_specification" />
+                            <field name="e_com_searchable" />
+                            <field
+                                name="e_com_range_filter"
+                                invisible="attribute_type not in ('integer', 'float')"
+                            />
+                            <field
+                                name="e_com_multi_select"
+                                invisible="attribute_type not in ('select', 'multiselect')"
+                            />
+                            <field name="e_com_show_count" />
+                        </group>
                     </group>
                 </xpath>
             </data>

--- a/website_attribute_set/views/templates.xml
+++ b/website_attribute_set/views/templates.xml
@@ -3,7 +3,7 @@
     <template id="filter_select_attributes" name="Select attributes in Filter">
         <select
             class="form-select css_attribute_select"
-            name="additional_attribute_value"
+            name="additional_attribute_values"
         >
             <option value="" selected="true">All <t
                 t-out="attribute.field_description"
@@ -39,7 +39,7 @@
                     <input
                         type="checkbox"
                         class="form-check-input"
-                        name="additional_attribute_value"
+                        name="additional_attribute_values"
                         t-att-id="'additional_attr_%s_%s' % (attribute.id, value.id)"
                         t-att-value="'%s-name-%s-id-%s' % (attribute.id,value._name,value.id)"
                         t-att-checked="'checked' if (attribute.id, option_code) in additional_attrib_set else None"
@@ -83,7 +83,7 @@
         <t t-foreach="all_attribute_values" t-as="value">
             <input
                 type="checkbox"
-                name="additional_attribute_value"
+                name="additional_attribute_values"
                 class="btn-check"
                 t-att-id="'%s-%s' % (attribute.id,value)"
                 t-att-value="'%s-%s' % (attribute.id,value)"
@@ -115,7 +115,7 @@
                 <div class="form-check mb-1">
                     <input
                         type="checkbox"
-                        name="additional_attribute_value"
+                        name="additional_attribute_values"
                         class="form-check-input"
                         t-att-id="'%s-%s' % (attribute.id, value)"
                         t-att-value="'%s-%s' % (attribute.id, value)"
@@ -365,7 +365,7 @@
                             >
                                 <select
                                     class="form-select css_attribute_select"
-                                    name="additional_attribute_value"
+                                    name="additional_attribute_values"
                                 >
                                     <option value="" selected="true">All <t
                                         t-out="attribute.field_description"

--- a/website_attribute_set/views/templates.xml
+++ b/website_attribute_set/views/templates.xml
@@ -166,17 +166,28 @@
         </t>
     </template>
 
+    <!-- Extend the filter panel to show when additional attributes exist -->
     <template
         id="products_additional_attributes"
         inherit_id="website_sale.products_attributes"
         active="True"
         name="Attributes &amp; Variants filters"
     >
+        <xpath expr="//div[@id='wsale_products_attributes_collapse']" position="before">
+            <t
+                t-set="additional_filter_attributes"
+                t-value="[x for x in (additional_attributes or []) if x['attribute'].e_com_filter]"
+            />
+        </xpath>
         <xpath
             expr="//div[@id='wsale_products_attributes_collapse']"
             position="attributes"
         >
-            <attribute name="t-if" add="additional_attributes" separator=" or " />
+            <attribute
+                name="t-if"
+                add="additional_filter_attributes"
+                separator=" or "
+            />
         </xpath>
     </template>
 
@@ -211,12 +222,13 @@
             <attribute
                 name="t-attf-class"
                 remove="{{not (product.valid_product_template_attribute_line_ids or product._has_multiple_uoms()) and 'd-none' or ''}}"
-                add="{{not (product.valid_product_template_attribute_line_ids or product.attribute_set_id.attribute_ids or product._has_multiple_uoms()) and 'd-none' or ''}}"
+                add="{{not (product.valid_product_template_attribute_line_ids or product.attribute_set_id.attribute_ids.filtered(lambda a: a.e_com_specification) or product._has_multiple_uoms()) and 'd-none' or ''}}"
                 separator=" "
             />
         </xpath>
     </template>
 
+    <!-- Inject additional attribute filter inputs inside the filter form -->
     <template
         id="product_additional_attribute_filters_form"
         inherit_id="website_sale.product_attribute_filters_form"
@@ -224,10 +236,14 @@
     >
         <xpath expr="//form" position="inside">
             <t
-                t-set="visible_attributes"
-                t-value="len([a for a in attributes if a.value_ids and len(a.value_ids) &gt; 1]) + len([attribute_dict for attribute_dict in additional_attributes if attribute_dict.get('all_attribute_values') and len(attribute_dict.get('all_attribute_values')) &gt; 0])"
+                t-set="additional_filter_attributes"
+                t-value="[x for x in (additional_attributes or []) if x['attribute'].e_com_filter]"
             />
-            <t t-foreach="additional_attributes" t-as="attribute_dict">
+            <t
+                t-set="visible_attributes"
+                t-value="len([a for a in attributes if a.value_ids and len(a.value_ids) &gt; 1]) + len([attribute_dict for attribute_dict in additional_filter_attributes if attribute_dict.get('all_attribute_values') and len(attribute_dict.get('all_attribute_values')) &gt; 0])"
+            />
+            <t t-foreach="additional_filter_attributes" t-as="attribute_dict">
                 <t t-set="attribute" t-value="attribute_dict.get('attribute')" />
                 <t
                     t-set="all_attribute_values"

--- a/website_attribute_set/views/variant_templates.xml
+++ b/website_attribute_set/views/variant_templates.xml
@@ -2,10 +2,17 @@
 <odoo>
     <template id="variants" inherit_id="website_sale.variants">
         <xpath expr="//ul" position="after">
+            <t
+                t-set="additional_specification_attributes"
+                t-value="[x for x in (additional_attributes or []) if x['attribute'].e_com_specification]"
+            />
             <ul
-                t-attf-class="o_wsale_product_page_variants d-flex flex-column gap-4 list-unstyled js_add_cart_variants #{ul_class} #{'d-none' if not additional_attributes else '' }"
+                t-attf-class="o_wsale_product_page_variants d-flex flex-column gap-4 list-unstyled js_add_cart_variants #{ul_class} #{'d-none' if not additional_specification_attributes else '' }"
             >
-                <t t-foreach="additional_attributes" t-as="attribute_dict">
+                <t
+                    t-foreach="additional_specification_attributes"
+                    t-as="attribute_dict"
+                >
                     <t t-set="attribute" t-value="attribute_dict.get('attribute')" />
                     <t
                         t-set="attribute_values"


### PR DESCRIPTION
Add is_filter and is_specification boolean fields to attribute.attribute,
allowing fine-grained control over where each attribute appears in the
e-commerce frontend:

- is_filter: controls whether the attribute appears as a shop filter
  and is included in search results
- is_specification: controls whether the attribute appears in the
  product page specifications table and comparison view

Both fields default to False and require e_com_visibility to be enabled
(enforced via constraints). An onchange on e_com_visibility auto-enables
both fields when visibility is turned on, and clears them when turned off.

Templates now filter additional_attributes by is_filter (shop filters)
and is_specification (product page, comparison) accordingly.

@MiquelRForgeFlow 