### PR TITLE
[19.0][FIX] product_attribute_set: keep attribute_set_id when category has none

### DIFF
--- a/product_attribute_set/models/product.py
+++ b/product_attribute_set/models/product.py
@@ -28,13 +28,15 @@ class ProductTemplate(models.Model):
         for vals in vals_list:
             if not vals.get("attribute_set_id") and vals.get("categ_id"):
                 category = category_model.browse(vals["categ_id"])
-                vals["attribute_set_id"] = category.attribute_set_id.id
+                if category.attribute_set_id:
+                    vals["attribute_set_id"] = category.attribute_set_id.id
         return super().create(vals_list)
 
     def write(self, vals):
         if not vals.get("attribute_set_id") and vals.get("categ_id"):
             category = self.env["product.category"].browse(vals["categ_id"])
-            vals["attribute_set_id"] = category.attribute_set_id.id
+            if category.attribute_set_id:
+                vals["attribute_set_id"] = category.attribute_set_id.id
         return super().write(vals)
 
     @api.onchange("categ_id")


### PR DESCRIPTION
Currently if you maintain attribute set at product level, and not at category level, when assigning the category to the product you will loose the attribute set that was assigned to the product.

When categ_id is written without attribute_set_id, the create/write overrides looked up the category's default attribute_set_id and assigned it unconditionally. If the category had no default set, category.attribute_set_id.id evaluated to False and the product's existing attribute_set_id was overwritten with False, dropping a previously assigned set. Only auto-fill from the category when the category actually has one.