### PR TITLE
[19.0][FIX] website_attribute_set: render display_name for relational attribute values

### DIFF
--- a/website_attribute_set/models/product_product.py
+++ b/website_attribute_set/models/product_product.py
@@ -43,11 +43,11 @@ class ProductProduct(models.Model):
                 if isinstance(values, models.BaseModel):
                     if len(values) == 1:
                         groups[attribute.attribute_group_id][attribute][product] = (
-                            values.name
+                            values.display_name
                         )
                     elif len(values) > 1:
                         groups[attribute.attribute_group_id][attribute][product] = (
-                            values.mapped("name")
+                            values.mapped("display_name")
                         )
                 elif values:
                     groups[attribute.attribute_group_id][attribute][product] = values

--- a/website_attribute_set/models/product_template.py
+++ b/website_attribute_set/models/product_template.py
@@ -40,10 +40,12 @@ class ProductTemplate(models.Model):
             values = self.get_extra_attribute_values(attribute)
             if isinstance(values, models.BaseModel):
                 if len(values) == 1:
-                    groups[attribute.attribute_group_id][attribute] = [values.name]
+                    groups[attribute.attribute_group_id][attribute] = [
+                        values.display_name
+                    ]
                 elif len(values) > 1:
                     groups[attribute.attribute_group_id][attribute] = values.mapped(
-                        "name"
+                        "display_name"
                     )
             elif values:
                 groups[attribute.attribute_group_id][attribute] = values

--- a/website_attribute_set/views/variant_templates.xml
+++ b/website_attribute_set/views/variant_templates.xml
@@ -62,7 +62,7 @@
                                                     t-out="'+'"
                                                 />
                                                 <span
-                                                    t-out="select_option.name"
+                                                    t-out="select_option.display_name"
                                                     class="variant_price_extra text-muted fst-italic"
                                                     style="white-space: nowrap;"
                                                 />


### PR DESCRIPTION
The product page and spec dicts rendered .name for attribute values that are recordsets, which strips the contextual prefix/suffix that target models often add via display_name (e.g. "[CODE] Name"). This is most visible for native many2one / many2many attributes where display_name is overridden on the target model.