### PR TITLE
[19.0][IMP] website_attribute_set: batch attribute resolution on shop

### DIFF
--- a/website_attribute_set/controllers/main.py
+++ b/website_attribute_set/controllers/main.py
@@ -2,6 +2,8 @@
 # @author Mohamed Alkobrosli <malkobrosly@kencove.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from collections import defaultdict
+
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.models import BaseModel
@@ -87,62 +89,88 @@ class WebsiteSale(main.WebsiteSale):
         extra_values["additional_attributes"] = []
 
         search_product = values.get("search_product")
+        if not search_product:
+            return extra_values
+
+        sudo_products = search_product.sudo()
+        sudo_products.fetch(["attribute_set_id"])
+        set_ids = {p.attribute_set_id.id for p in sudo_products if p.attribute_set_id}
+        if not set_ids:
+            return extra_values
+
+        attrs_per_set = sudo_products._get_extra_attributes_per_set(list(set_ids))
         all_additional_attributes = request.env["attribute.attribute"].sudo()
-        product_attrs_map = {}
-        if search_product:
-            set_ids = list(
-                {p.attribute_set_id.id for p in search_product if p.attribute_set_id}
+        attr_ids_per_set = {}
+        for sid, attrs in attrs_per_set.items():
+            all_additional_attributes |= attrs
+            attr_ids_per_set[sid] = set(attrs.ids)
+        if not all_additional_attributes:
+            return extra_values
+
+        product_ids_per_attr = defaultdict(list)
+        for product in sudo_products:
+            sid = product.attribute_set_id.id
+            if not sid:
+                continue
+            for attr_id in attr_ids_per_set.get(sid, ()):
+                product_ids_per_attr[attr_id].append(product.id)
+
+        for attribute in all_additional_attributes:
+            attr_dict = self._build_additional_attribute_facet(
+                attribute, sudo_products, product_ids_per_attr
             )
-            attrs_per_set = (
-                search_product.sudo()._get_extra_attributes_per_set(set_ids)
-                if set_ids
-                else {}
-            )
-            for product in search_product:
-                additional_attributes = attrs_per_set.get(product.attribute_set_id.id)
-                if additional_attributes:
-                    product_attrs_map[product.id] = additional_attributes
-                    all_additional_attributes |= additional_attributes
-
-            if all_additional_attributes:
-                for attribute in all_additional_attributes:
-                    all_attribute_values = set()
-                    value_counts = {}
-
-                    for product in search_product:
-                        if attribute not in product_attrs_map.get(product.id, []):
-                            continue
-                        attribute_values = product.sudo().get_extra_attribute_values(
-                            attribute
-                        )
-                        if attribute_values:
-                            if (
-                                isinstance(attribute_values, BaseModel)
-                                and len(attribute_values) > 1
-                            ):
-                                for rec in attribute_values:
-                                    all_attribute_values.add(rec)
-                                    if attribute.e_com_show_count:
-                                        key = rec.id if hasattr(rec, "id") else rec
-                                        value_counts[key] = value_counts.get(key, 0) + 1
-                            else:
-                                all_attribute_values.add(attribute_values)
-                                if attribute.e_com_show_count:
-                                    if hasattr(attribute_values, "id"):
-                                        key = attribute_values.id
-                                    else:
-                                        key = attribute_values
-                                    value_counts[key] = value_counts.get(key, 0) + 1
-
-                    attr_dict = {
-                        "attribute": attribute,
-                        "all_attribute_values": list(all_attribute_values),
-                    }
-                    if attribute.e_com_show_count:
-                        attr_dict["value_counts"] = value_counts
-                    extra_values["additional_attributes"].append(attr_dict)
+            if attr_dict is not None:
+                extra_values["additional_attributes"].append(attr_dict)
 
         return extra_values
+
+    def _build_additional_attribute_facet(
+        self, attribute, sudo_products, product_ids_per_attr
+    ):
+        """Build the facet dict for a single additional attribute.
+
+        Returns ``None`` when no product in the current shop result carries a
+        value for ``attribute``, so the caller can skip it.
+        """
+        pids = product_ids_per_attr.get(attribute.id)
+        if not pids:
+            return None
+        attr_type = attribute.attribute_type or attribute.ttype
+        field_name = (
+            f"{attribute.name}_filename"
+            if attr_type in ("binary", "image")
+            else attribute.name
+        )
+        attr_products = sudo_products.browse(pids)
+        attr_products.mapped(field_name)
+        all_attribute_values = set()
+        value_counts = {}
+        for product in attr_products:
+            attribute_values = product[field_name] or None
+            if not attribute_values:
+                continue
+            if isinstance(attribute_values, BaseModel) and len(attribute_values) > 1:
+                for rec in attribute_values:
+                    all_attribute_values.add(rec)
+                    if attribute.e_com_show_count:
+                        key = rec.id if hasattr(rec, "id") else rec
+                        value_counts[key] = value_counts.get(key, 0) + 1
+            else:
+                all_attribute_values.add(attribute_values)
+                if attribute.e_com_show_count:
+                    key = (
+                        attribute_values.id
+                        if hasattr(attribute_values, "id")
+                        else attribute_values
+                    )
+                    value_counts[key] = value_counts.get(key, 0) + 1
+        attr_dict = {
+            "attribute": attribute,
+            "all_attribute_values": list(all_attribute_values),
+        }
+        if attribute.e_com_show_count:
+            attr_dict["value_counts"] = value_counts
+        return attr_dict
 
     def _get_shop_domain(self, search, category, attribute_value_dict, **kwargs):
         """Extend shop domain with additional attribute filters."""

--- a/website_attribute_set/controllers/main.py
+++ b/website_attribute_set/controllers/main.py
@@ -90,8 +90,16 @@ class WebsiteSale(main.WebsiteSale):
         all_additional_attributes = request.env["attribute.attribute"].sudo()
         product_attrs_map = {}
         if search_product:
+            set_ids = list(
+                {p.attribute_set_id.id for p in search_product if p.attribute_set_id}
+            )
+            attrs_per_set = (
+                search_product.sudo()._get_extra_attributes_per_set(set_ids)
+                if set_ids
+                else {}
+            )
             for product in search_product:
-                additional_attributes = product.sudo().get_extra_attributes()
+                additional_attributes = attrs_per_set.get(product.attribute_set_id.id)
                 if additional_attributes:
                     product_attrs_map[product.id] = additional_attributes
                     all_additional_attributes |= additional_attributes

--- a/website_attribute_set/models/attribute_set_owner.py
+++ b/website_attribute_set/models/attribute_set_owner.py
@@ -2,7 +2,7 @@
 # @author Mohamed Alkobrosli <malkobrosly@kencove.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class AttributeSetOwnerMixin(models.AbstractModel):
@@ -18,18 +18,37 @@ class AttributeSetOwnerMixin(models.AbstractModel):
         set, matching the behaviour of the backend form view.
         """
         self.ensure_one()
-        domain = [
-            ("model", "=", self._name),
-            ("attribute_set_ids", "!=", False),
-        ]
+        if not self.attribute_set_id:
+            return self.env["attribute.attribute"]
+        return self._get_extra_attributes_per_set(self.attribute_set_id.ids).get(
+            self.attribute_set_id.id, self.env["attribute.attribute"]
+        )
+
+    @api.model
+    def _get_extra_attributes_per_set(self, attribute_set_ids):
+        """Return ``{attribute_set_id: attributes_recordset}`` for given sets.
+
+        Batched counterpart of :meth:`get_extra_attributes`: resolves each
+        attribute's descendant attribute sets only once instead of once per
+        owner record, which removes the quadratic ``child_of`` search cost
+        when the method is used over a listing (e.g. the shop page).
+        """
         attribute = self.env["attribute.attribute"]
-        if self.attribute_set_id:
-            attributes = attribute.search(domain)
-            attribute_set_id = self.attribute_set_id
-            filtered_attributes = attributes.filtered(
-                lambda rec: attribute_set_id.id in rec._get_all_set_ids()
-                and rec.e_com_visibility
+        if not attribute_set_ids:
+            return {}
+        attributes = attribute.search(
+            [
+                ("model", "=", self._name),
+                ("attribute_set_ids", "!=", False),
+                ("e_com_visibility", "=", True),
+            ]
+        )
+        attr_descendants = {
+            attr.id: set(attr._get_all_set_ids()) for attr in attributes
+        }
+        result = {}
+        for set_id in set(attribute_set_ids):
+            result[set_id] = attributes.filtered(
+                lambda a, sid=set_id: sid in attr_descendants[a.id]
             )
-            return filtered_attributes
-        else:
-            return attribute
+        return result

--- a/website_attribute_set/views/templates.xml
+++ b/website_attribute_set/views/templates.xml
@@ -222,7 +222,7 @@
             <attribute
                 name="t-attf-class"
                 remove="{{not (product.valid_product_template_attribute_line_ids or product._has_multiple_uoms()) and 'd-none' or ''}}"
-                add="{{not (product.valid_product_template_attribute_line_ids or product.attribute_set_id.attribute_ids.filtered(lambda a: a.e_com_specification) or product._has_multiple_uoms()) and 'd-none' or ''}}"
+                add="{{not (product.valid_product_template_attribute_line_ids or product.sudo().attribute_set_id.attribute_ids.filtered(lambda a: a.e_com_specification) or product._has_multiple_uoms()) and 'd-none' or ''}}"
                 separator=" "
             />
         </xpath>

--- a/website_attribute_set/views/variant_templates.xml
+++ b/website_attribute_set/views/variant_templates.xml
@@ -40,7 +40,7 @@
                                 <ul
                                     t-att-data-attribute_id="attribute.id"
                                     t-attf-class="list-inline list-unstyled o_wsale_product_attribute"
-                                    t-att-name="'set-%s-attr-%s' % (product.attribute_set_id.id, attribute.id)"
+                                    t-att-name="'set-%s-attr-%s' % (product.sudo().attribute_set_id.id, attribute.id)"
                                 >
                                     <t
                                         t-foreach="attribute_values"
@@ -77,7 +77,7 @@
                                 <ul
                                     t-att-data-attribute_id="attribute.id"
                                     t-attf-class="list-inline list-unstyled o_wsale_product_attribute"
-                                    t-att-name="'set-%s-attr-%s' % (product.attribute_set_id.id, attribute.id)"
+                                    t-att-name="'set-%s-attr-%s' % (product.sudo().attribute_set_id.id, attribute.id)"
                                 >
                                     <li
                                         t-att-value="'%s-%s' % (attribute.id,attribute_values)"


### PR DESCRIPTION
Improve performance by batching the attribute resolution.

For reference, before this PR our client's website loaded in 45 seconds:
<img width="1919" height="452" alt="image" src="https://github.com/user-attachments/assets/85ee628f-d933-496d-8793-a1af1e9fac4e" />

Now it takes 5s:
<img width="1912" height="769" alt="image" src="https://github.com/user-attachments/assets/b51beb91-035a-4b5d-bc8a-53ce444742d0" />
