### PR TITLE
[19.0][FIX] website_attribute_set: support sparse fields in shop search and filter

### DIFF
--- a/attribute_set/models/attribute_attribute.py
+++ b/attribute_set/models/attribute_attribute.py
@@ -331,6 +331,29 @@ class AttributeAttribute(models.Model):
             "target": "new",
         }
 
+    # Attribute types whose ORM convert_to_read() returns a Python object that
+    # json.dumps() cannot serialise (datetime, date, bytes).  Until
+    # base_sparse_field normalises these before writing the JSON blob, combining
+    # such types with serialized=True would cause a TypeError at save time.
+    _SERIALIZED_INCOMPATIBLE_TYPES = ("date", "datetime", "binary", "image")
+
+    @api.constrains("attribute_type", "serialized")
+    def _check_serialized_type_compatibility(self):
+        for rec in self:
+            if (
+                rec.serialized
+                and rec.attribute_type in self._SERIALIZED_INCOMPATIBLE_TYPES
+            ):
+                raise ValidationError(
+                    self.env._(
+                        "The attribute type '%(attr_type)s' is not compatible with "
+                        "the 'Serialized' option because its value cannot be stored "
+                        "as JSON. Please uncheck 'Serialized' or choose a "
+                        "different attribute type.",
+                        attr_type=rec.attribute_type,
+                    )
+                )
+
     @api.model_create_multi
     def create(self, vals_list):
         """Create an attribute.attribute

--- a/attribute_set/views/attribute_attribute_view.xml
+++ b/attribute_set/views/attribute_attribute_view.xml
@@ -49,7 +49,7 @@
                             <field
                                 name="serialized"
                                 readonly="create_date"
-                                invisible="nature == 'native'"
+                                invisible="nature == 'native' or attribute_type in ['date', 'datetime', 'binary', 'image']"
                             />
                         </group>
                         <newline />
@@ -143,6 +143,7 @@
                 />
                 <field name="field_description" />
                 <field name="attribute_type" />
+                <field name="serialized" optional="hide" />
                 <field name="attribute_group_id" />
                 <field name="attribute_set_ids" widget="many2many_tags" />
                 <field name="nature" />

--- a/website_attribute_set/controllers/main.py
+++ b/website_attribute_set/controllers/main.py
@@ -199,7 +199,7 @@ class WebsiteSale(main.WebsiteSale):
         Attribute = request.env["attribute.attribute"].sudo()
         for attr_id, range_vals in range_filters.items():
             attribute = Attribute.browse(attr_id)
-            if not attribute.exists():
+            if not attribute.exists() or not attribute.field_is_searchable:
                 continue
             field_name = attribute.name
             if "min" in range_vals:
@@ -222,7 +222,7 @@ class WebsiteSale(main.WebsiteSale):
 
         for attr_id, values in attr_values_grouped.items():
             attribute = Attribute.browse(attr_id)
-            if not attribute.exists():
+            if not attribute.exists() or not attribute.field_is_searchable:
                 continue
 
             field_name = attribute.name

--- a/website_attribute_set/controllers/main.py
+++ b/website_attribute_set/controllers/main.py
@@ -10,6 +10,8 @@ from odoo.models import BaseModel
 
 from odoo.addons.website_sale.controllers import main
 
+from ..models.mixins import _sparse_filter_by_range, _sparse_filter_by_value
+
 
 class WebsiteSale(main.WebsiteSale):
     def _parse_additional_attrib_values(self):
@@ -202,10 +204,19 @@ class WebsiteSale(main.WebsiteSale):
             if not attribute.exists() or not attribute.field_is_searchable:
                 continue
             field_name = attribute.name
+            field = request.env["product.template"]._fields.get(field_name)
+            sparse_col = getattr(field, "sparse", None) if field else None
+            if sparse_col:
+                ids = _sparse_filter_by_range(
+                    request.env, "product.template", sparse_col, field_name, range_vals
+                )
+                if ids:
+                    conditions.append([("id", "in", ids)])
+                continue
             if "min" in range_vals:
-                conditions.append((field_name, ">=", range_vals["min"]))
+                conditions.append([(field_name, ">=", range_vals["min"])])
             if "max" in range_vals:
-                conditions.append((field_name, "<=", range_vals["max"]))
+                conditions.append([(field_name, "<=", range_vals["max"])])
         return conditions
 
     def _build_value_filter_conditions(self, attrib_values):
@@ -227,6 +238,37 @@ class WebsiteSale(main.WebsiteSale):
 
             field_name = attribute.name
             attr_type = attribute.attribute_type
+            field = request.env["product.template"]._fields.get(field_name)
+            sparse_col = getattr(field, "sparse", None) if field else None
+            if sparse_col:
+                if len(values) > 1 and attribute.e_com_multi_select:
+                    all_ids = []
+                    for v in values:
+                        all_ids.extend(
+                            _sparse_filter_by_value(
+                                request.env,
+                                "product.template",
+                                sparse_col,
+                                field_name,
+                                attr_type,
+                                v,
+                            )
+                        )
+                    if all_ids:
+                        conditions.append([("id", "in", list(set(all_ids)))])
+                else:
+                    for attr_value in values:
+                        ids = _sparse_filter_by_value(
+                            request.env,
+                            "product.template",
+                            sparse_col,
+                            field_name,
+                            attr_type,
+                            attr_value,
+                        )
+                        if ids:
+                            conditions.append([("id", "in", ids)])
+                continue
 
             if len(values) > 1 and attribute.e_com_multi_select:
                 or_conds = [

--- a/website_attribute_set/controllers/main.py
+++ b/website_attribute_set/controllers/main.py
@@ -10,16 +10,36 @@ from odoo.models import BaseModel
 
 from odoo.addons.website_sale.controllers import main
 
-from ..models.mixins import _sparse_filter_by_range, _sparse_filter_by_value
+from ..models.mixins import (
+    _parse_relational_id,
+    _sparse_filter_by_range,
+    _sparse_filter_by_value,
+)
 
 
 class WebsiteSale(main.WebsiteSale):
     def _parse_additional_attrib_values(self):
-        """Parse additional_attribute_values params from the request."""
+        """Parse additional_attribute_values params from the request.
+
+        The JS handler (onChangeAttribute) groups all selected values for the
+        same attribute into a single URL param by joining them with a comma:
+          additional_attribute_values=42-val1,val2,val3
+
+        This method splits them back so every (attr_id, value) pair is
+        returned as a separate two-element list.
+        """
         request_args = request.httprequest.args
         raw_list = request_args.getlist("additional_attribute_values")
-        parsed = [[x for x in v.split("-", maxsplit=1)] for v in raw_list if v]
-        return [[int(sublist[0]), sublist[1]] for sublist in parsed]
+        result = []
+        for raw in raw_list:
+            if not raw:
+                continue
+            first_dash = raw.index("-")
+            attr_id = int(raw[:first_dash])
+            for value in raw[first_dash + 1 :].split(","):
+                if value:
+                    result.append([attr_id, value])
+        return result
 
     def _parse_additional_range_filters(self):
         """Parse additional_attr_min_/max_ params from the request."""
@@ -148,8 +168,10 @@ class WebsiteSale(main.WebsiteSale):
         all_attribute_values = set()
         value_counts = {}
         for product in attr_products:
-            attribute_values = product[field_name] or None
-            if not attribute_values:
+            attribute_values = product[field_name]
+            # For boolean, False is a valid filter value (not "no value").
+            # For every other type, falsy means nothing is set.
+            if not attribute_values and attr_type != "boolean":
                 continue
             if isinstance(attribute_values, BaseModel) and len(attribute_values) > 1:
                 for rec in attribute_values:
@@ -293,11 +315,12 @@ class WebsiteSale(main.WebsiteSale):
             value = attr_value.lower() == "true"
             return [(field_name, "=", value)]
         elif attr_type in ("select", "multiselect"):
-            try:
-                option_id = int(attr_value)
-                return [(field_name, "=", option_id)]
-            except (ValueError, TypeError):
+            # The URL value may be a plain integer string or the
+            # 'name-{model}-id-{N}' format from the filter template.
+            option_id = _parse_relational_id(attr_value)
+            if option_id is None:
                 return None
+            return [(field_name, "=", option_id)]
         elif attr_type == "integer":
             try:
                 value = int(attr_value)

--- a/website_attribute_set/controllers/main.py
+++ b/website_attribute_set/controllers/main.py
@@ -190,7 +190,18 @@ class WebsiteSale(main.WebsiteSale):
                     value_counts[key] = value_counts.get(key, 0) + 1
         attr_dict = {
             "attribute": attribute,
-            "all_attribute_values": list(all_attribute_values),
+            "all_attribute_values": sorted(
+                all_attribute_values,
+                key=lambda v: v.display_name
+                if hasattr(v, "display_name")
+                else (
+                    v
+                    if isinstance(v, (int, float))
+                    else str(v)
+                    if v is not None
+                    else ""
+                ),
+            ),
         }
         if attribute.e_com_show_count:
             attr_dict["value_counts"] = value_counts

--- a/website_attribute_set/demo/website_attribute_demo.xml
+++ b/website_attribute_set/demo/website_attribute_demo.xml
@@ -50,6 +50,7 @@
         <field name="model_id" ref="product.model_product_template" />
         <field name="e_com_visibility" eval="True" />
         <field name="e_com_searchable" eval="True" />
+        <field name="e_com_filter" eval="True" />
         <field name="e_com_multi_select" eval="True" />
         <field name="e_com_show_count" eval="True" />
     </record>
@@ -79,6 +80,7 @@
         <field name="model_id" ref="product.model_product_template" />
         <field name="e_com_visibility" eval="True" />
         <field name="e_com_searchable" eval="True" />
+        <field name="e_com_filter" eval="True" />
         <field name="e_com_range_filter" eval="True" />
     </record>
 

--- a/website_attribute_set/models/attribute_attribute.py
+++ b/website_attribute_set/models/attribute_attribute.py
@@ -11,6 +11,12 @@ from odoo.tools.safe_eval import safe_eval
 class AttributeAttribute(models.Model):
     _inherit = "attribute.attribute"
 
+    field_is_searchable = fields.Boolean(
+        compute="_compute_field_is_searchable",
+        help="Whether the underlying field can be searched "
+        "(stored in SQL or has a search method).",
+    )
+
     e_com_visibility = fields.Boolean(
         string="E-Commerce Visibility",
         default=False,
@@ -50,6 +56,19 @@ class AttributeAttribute(models.Model):
         help="""Show the number of matching products next to each filter option.""",
     )
 
+    @api.depends("name", "model_id")
+    def _compute_field_is_searchable(self):
+        for rec in self:
+            if not rec.name or not rec.model_id:
+                rec.field_is_searchable = False
+                continue
+            model_obj = self.env.get(rec.model_id.model)
+            if model_obj is None:
+                rec.field_is_searchable = False
+                continue
+            field = model_obj._fields.get(rec.name)
+            rec.field_is_searchable = bool(field and (field.store or field.search))
+
     @api.constrains("e_com_filter")
     def _check_e_com_filter(self):
         for rec in self:
@@ -58,6 +77,14 @@ class AttributeAttribute(models.Model):
                     self.env._(
                         "Cannot use attribute as filter "
                         "if it doesn't have E-Commerce Visibility enabled."
+                    )
+                )
+            if rec.e_com_filter and not rec.field_is_searchable:
+                raise ValidationError(
+                    self.env._(
+                        "Cannot use attribute '%s' as filter "
+                        "because its field is neither stored nor has a search method.",
+                        rec.field_description,
                     )
                 )
 
@@ -80,6 +107,14 @@ class AttributeAttribute(models.Model):
                     self.env._(
                         "Cannot make attribute searchable "
                         "if it doesn't have E-Commerce Visibility enabled."
+                    )
+                )
+            if rec.e_com_searchable and not rec.field_is_searchable:
+                raise ValidationError(
+                    self.env._(
+                        "Cannot make attribute '%s' searchable "
+                        "because its field is neither stored nor has a search method.",
+                        rec.field_description,
                     )
                 )
 

--- a/website_attribute_set/models/attribute_attribute.py
+++ b/website_attribute_set/models/attribute_attribute.py
@@ -67,7 +67,10 @@ class AttributeAttribute(models.Model):
                 rec.field_is_searchable = False
                 continue
             field = model_obj._fields.get(rec.name)
-            rec.field_is_searchable = bool(field and (field.store or field.search))
+            rec.field_is_searchable = bool(
+                field
+                and (field.store or field.search or getattr(field, "sparse", None))
+            )
 
     @api.constrains("e_com_filter")
     def _check_e_com_filter(self):

--- a/website_attribute_set/models/mixins.py
+++ b/website_attribute_set/models/mixins.py
@@ -11,6 +11,72 @@ from odoo.fields import Domain
 _logger = logging.getLogger(__name__)
 
 
+def _sparse_search_ilike(env, model_name, sparse_col, field_name, search_term):
+    table = env[model_name]._table
+    env.cr.execute(
+        f"SELECT id FROM {table} WHERE {sparse_col}::jsonb ->> %s ILIKE %s",
+        (field_name, f"%{search_term}%"),
+    )
+    return [row[0] for row in env.cr.fetchall()]
+
+
+_SPARSE_CAST = {
+    "boolean": ("boolean", lambda v: str(v).lower() == "true"),
+    "integer": ("integer", int),
+    "select": ("integer", int),
+    "float": ("numeric", float),
+}
+
+
+def _sparse_filter_by_value(
+    env, model_name, sparse_col, field_name, attr_type, attr_value
+):
+    table = env[model_name]._table
+    try:
+        if attr_type == "multiselect":
+            sql = (
+                f"SELECT id FROM {table}"
+                f" WHERE ({sparse_col}::jsonb -> %s)"
+                f" @> jsonb_build_array(%s::integer)"
+            )
+            env.cr.execute(sql, (field_name, int(attr_value)))
+            return [row[0] for row in env.cr.fetchall()]
+        cast_info = _SPARSE_CAST.get(attr_type)
+        if cast_info:
+            cast_type, coerce = cast_info
+            sql = (
+                f"SELECT id FROM {table}"
+                f" WHERE ({sparse_col}::jsonb ->> %s)::{cast_type} = %s"
+            )
+            value = coerce(attr_value)
+        else:
+            sql = f"SELECT id FROM {table} WHERE {sparse_col}::jsonb ->> %s = %s"
+            value = str(attr_value)
+        env.cr.execute(sql, (field_name, value))
+        return [row[0] for row in env.cr.fetchall()]
+    except (ValueError, TypeError):
+        return []
+
+
+def _sparse_filter_by_range(env, model_name, sparse_col, field_name, range_vals):
+    table = env[model_name]._table
+    parts = []
+    params = []
+    if "min" in range_vals:
+        parts.append(f"({sparse_col}::jsonb ->> %s)::numeric >= %s")
+        params += [field_name, range_vals["min"]]
+    if "max" in range_vals:
+        parts.append(f"({sparse_col}::jsonb ->> %s)::numeric <= %s")
+        params += [field_name, range_vals["max"]]
+    if not parts:
+        return []
+    env.cr.execute(
+        f"SELECT id FROM {table} WHERE {' AND '.join(parts)}",
+        params,
+    )
+    return [row[0] for row in env.cr.fetchall()]
+
+
 def search_extra(env, search_term):
     extra_domains = []
     attributes = (
@@ -19,10 +85,19 @@ def search_extra(env, search_term):
     product_template_fields = env["product.template"]._fields
     for attribute in attributes:
         field = product_template_fields.get(attribute.name)
-        if not field or not (field.store or field.search):
+        sparse_col = getattr(field, "sparse", None) if field else None
+        if not field or not (field.store or field.search or sparse_col):
             _logger.debug(
                 "Skipping non-searchable field %s in e-commerce search", attribute.name
             )
+            continue
+        if sparse_col:
+            if attribute.attribute_type in ["char", "text"]:
+                ids = _sparse_search_ilike(
+                    env, "product.template", sparse_col, attribute.name, search_term
+                )
+                if ids:
+                    extra_domains.append([("id", "in", ids)])
             continue
         if attribute.attribute_type in ["char", "text"]:
             extra_domain = [(attribute.name, "ilike", search_term)]
@@ -59,18 +134,24 @@ class WebsiteSearchableMixin(models.AbstractModel):
 
     @api.model
     def _search_fetch(self, search_detail, search, limit, order):
-        results, count = super()._search_fetch(
-            search_detail=search_detail, search=search, limit=limit, order=order
-        )
         model = self.sudo() if search_detail.get("requires_sudo") else self
-        if model._name == "product.template":
-            fields = search_detail["search_fields"]
-            base_domain = search_detail["base_domain"]
-            domain = self._search_build_domain(
-                base_domain, search, fields, search_extra
+        if model._name != "product.template":
+            return super()._search_fetch(
+                search_detail=search_detail, search=search, limit=limit, order=order
             )
-            results = model.search(
-                domain, limit=limit, order=search_detail.get("order", order)
-            )
-            count = model.search_count(domain)
+        # For product.template we extend the standard search with extra attribute
+        # domains (including sparse/serialized fields handled via raw JSONB queries).
+        # Calling super() first would fail when base_domain already contains
+        # conditions on sparse fields, so we build and run the domain ourselves.
+        fields = search_detail["search_fields"]
+        base_domain = search_detail["base_domain"]
+        domain = self._search_build_domain(base_domain, search, fields, search_extra)
+        results = model.search(
+            domain, limit=limit, order=search_detail.get("order", order)
+        )
+        count = (
+            model.search_count(domain)
+            if limit and limit == len(results)
+            else len(results)
+        )
         return results, count

--- a/website_attribute_set/models/mixins.py
+++ b/website_attribute_set/models/mixins.py
@@ -3,12 +3,31 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
+import re
 from difflib import SequenceMatcher
 
 from odoo import api, models
 from odoo.fields import Domain
 
 _logger = logging.getLogger(__name__)
+
+# Matches the 'name-{model.name}-id-{N}' format emitted by select/multiselect
+# filter templates, e.g. 'name-attribute.option-id-7'.
+_RE_RELATIONAL_ID = re.compile(r"-id-(\d+)$")
+
+
+def _parse_relational_id(attr_value):
+    """Return the integer record ID from a filter value string.
+
+    Handles both a plain integer string (``'7'``) and the
+    ``'name-{model}-id-{N}'`` format produced by the select/multiselect
+    filter templates.  Returns ``None`` if neither form can be parsed.
+    """
+    try:
+        return int(attr_value)
+    except (ValueError, TypeError):
+        m = _RE_RELATIONAL_ID.search(str(attr_value))
+        return int(m.group(1)) if m else None
 
 
 def _sparse_search_ilike(env, model_name, sparse_col, field_name, search_term):
@@ -21,9 +40,7 @@ def _sparse_search_ilike(env, model_name, sparse_col, field_name, search_term):
 
 
 _SPARSE_CAST = {
-    "boolean": ("boolean", lambda v: str(v).lower() == "true"),
     "integer": ("integer", int),
-    "select": ("integer", int),
     "float": ("numeric", float),
 }
 
@@ -33,13 +50,42 @@ def _sparse_filter_by_value(
 ):
     table = env[model_name]._table
     try:
-        if attr_type == "multiselect":
-            sql = (
-                f"SELECT id FROM {table}"
-                f" WHERE ({sparse_col}::jsonb -> %s)"
-                f" @> jsonb_build_array(%s::integer)"
-            )
-            env.cr.execute(sql, (field_name, int(attr_value)))
+        # Relational types store IDs; the URL value may be either a plain
+        # integer string or the 'name-{model}-id-{N}' template format.
+        if attr_type in ("select", "multiselect"):
+            option_id = _parse_relational_id(attr_value)
+            if option_id is None:
+                return []
+            if attr_type == "multiselect":
+                # many2many: stored as a JSON array of IDs
+                sql = (
+                    f"SELECT id FROM {table}"
+                    f" WHERE ({sparse_col}::jsonb -> %s)"
+                    f" @> jsonb_build_array(%s::integer)"
+                )
+            else:
+                # select (many2one): stored as a single integer ID
+                sql = (
+                    f"SELECT id FROM {table}"
+                    f" WHERE ({sparse_col}::jsonb ->> %s)::integer = %s"
+                )
+            env.cr.execute(sql, (field_name, option_id))
+            return [row[0] for row in env.cr.fetchall()]
+        if attr_type == "boolean":
+            value = str(attr_value).lower() == "true"
+            if value:
+                sql = (
+                    f"SELECT id FROM {table}"
+                    f" WHERE ({sparse_col}::jsonb ->> %s)::boolean = TRUE"
+                )
+                env.cr.execute(sql, (field_name,))
+            else:
+                sql = (
+                    f"SELECT id FROM {table}"
+                    f" WHERE ({sparse_col}::jsonb -> %s) IS NULL"
+                    f"    OR ({sparse_col}::jsonb ->> %s)::boolean = FALSE"
+                )
+                env.cr.execute(sql, (field_name, field_name))
             return [row[0] for row in env.cr.fetchall()]
         cast_info = _SPARSE_CAST.get(attr_type)
         if cast_info:

--- a/website_attribute_set/models/mixins.py
+++ b/website_attribute_set/models/mixins.py
@@ -16,7 +16,14 @@ def search_extra(env, search_term):
     attributes = (
         env["attribute.attribute"].sudo().search([("e_com_searchable", "=", True)])
     )
+    product_template_fields = env["product.template"]._fields
     for attribute in attributes:
+        field = product_template_fields.get(attribute.name)
+        if not field or not (field.store or field.search):
+            _logger.debug(
+                "Skipping non-searchable field %s in e-commerce search", attribute.name
+            )
+            continue
         if attribute.attribute_type in ["char", "text"]:
             extra_domain = [(attribute.name, "ilike", search_term)]
             extra_domains.append(extra_domain)

--- a/website_attribute_set/models/website.py
+++ b/website_attribute_set/models/website.py
@@ -6,6 +6,8 @@ import re
 
 from odoo import api, models
 
+from .mixins import _sparse_filter_by_value
+
 
 class Website(models.Model):
     _inherit = "website"
@@ -28,6 +30,26 @@ class Website(models.Model):
                     if attribute_field.attribute_type in ("binary", "image"):
                         attribute_name = f"{attribute_name}_filename"
                     additional_attrib_value = additional_attrib[1]
+
+                    # Sparse (serialized) fields cannot be used in ORM domain
+                    # conditions because they are not stored in their own SQL
+                    # column.  Resolve to a set of matching IDs via a raw JSONB
+                    # query so the base_domain stays SQL-safe.
+                    pt_field = self.env["product.template"]._fields.get(attribute_name)
+                    sparse_col = getattr(pt_field, "sparse", None) if pt_field else None
+                    if sparse_col:
+                        ids = _sparse_filter_by_value(
+                            self.env,
+                            "product.template",
+                            sparse_col,
+                            attribute_name,
+                            attribute_field.attribute_type,
+                            additional_attrib_value,
+                        )
+                        if ids:
+                            base_domain.append([("id", "in", ids)])
+                        continue
+
                     if attribute_field.attribute_type in (
                         "select",
                         "multiselect",

--- a/website_attribute_set/tests/__init__.py
+++ b/website_attribute_set/tests/__init__.py
@@ -3,5 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_website_attr_set
+from . import test_sparse_field_support
 from . import test_controller
 from . import test_shop_ui

--- a/website_attribute_set/tests/test_sparse_field_support.py
+++ b/website_attribute_set/tests/test_sparse_field_support.py
@@ -1,0 +1,94 @@
+# Copyright 2026 ForgeFlow (http://www.forgeflow.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.attribute_set.tests.test_build_view import BuildViewCase
+from odoo.addons.website_attribute_set.models.mixins import search_extra
+
+
+class TestSparseFieldSupport(BuildViewCase):
+    """Regression tests: sparse (base_sparse_field) attributes must work with
+    e-commerce search and filter without crashing.
+
+    Background: sparse fields have field.store=False in the ORM even though
+    their values are persisted in a shared JSON column. Before this fix, marking
+    a sparse attribute as e_com_searchable or e_com_filter and then triggering
+    a shop search/filter raised:
+        ValueError: Cannot convert product.template.<field> to SQL because it
+        is not stored
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        product_model = cls.env.ref("product.model_product_template")
+        group = cls.env["attribute.group"].create(
+            {
+                "name": "Sparse Group",
+                "model_id": product_model.id,
+                "sequence": 10,
+            }
+        )
+        attr_set = cls.env["attribute.set"].create(
+            {
+                "name": "Sparse Attribute Set",
+                "model_id": product_model.id,
+            }
+        )
+        # serialized=True creates the shared x_custom_json_attrs JSON column
+        # and makes this field a sparse field backed by it.
+        cls.attr_sparse = cls.env["attribute.attribute"].create(
+            {
+                "nature": "custom",
+                "field_description": "Dimension",
+                "name": "x_sparse_dimension",
+                "attribute_type": "char",
+                "attribute_group_id": group.id,
+                "attribute_set_ids": [(4, attr_set.id)],
+                "model_id": product_model.id,
+                "serialized": True,
+            }
+        )
+        cls.product_sparse = cls.env["product.template"].create(
+            {
+                "name": "Sparse Test Product",
+                "type": "consu",
+                "attribute_set_id": attr_set.id,
+                "x_sparse_dimension": "blue_42",
+            }
+        )
+
+    def test_field_is_searchable_for_sparse(self):
+        self.assertTrue(self.attr_sparse.field_is_searchable)
+
+    def test_constraint_allows_e_com_searchable_on_sparse(self):
+        # Must not raise ValidationError despite field.store=False
+        self.attr_sparse.write({"e_com_visibility": True, "e_com_searchable": True})
+
+    def test_constraint_allows_e_com_filter_on_sparse(self):
+        # Must not raise ValidationError despite field.store=False
+        self.attr_sparse.write({"e_com_visibility": True, "e_com_filter": True})
+
+    def test_search_extra_sparse_returns_matching_products(self):
+        self.attr_sparse.write({"e_com_visibility": True, "e_com_searchable": True})
+        domain = search_extra(self.env, "blue_42")
+        results = self.env["product.template"].search(domain)
+        self.assertIn(self.product_sparse, results)
+
+    def test_search_with_fuzzy_sparse_no_crash(self):
+        """Regression: _search_with_fuzzy must not 500 when a sparse field is
+        e_com_searchable."""
+        self.attr_sparse.write({"e_com_visibility": True, "e_com_searchable": True})
+        self.env["website"].browse(1)._search_with_fuzzy(
+            "all",
+            "blue_42",
+            limit=5,
+            order="name asc, website_id desc, id",
+            options={
+                "displayDescription": False,
+                "displayDetail": False,
+                "displayExtraDetail": False,
+                "displayExtraLink": False,
+                "displayImage": False,
+                "allowFuzzy": True,
+            },
+        )

--- a/website_attribute_set/tests/test_website_attr_set.py
+++ b/website_attribute_set/tests/test_website_attr_set.py
@@ -1,3 +1,4 @@
+# Copyright 2026 ForgeFlow (http://www.forgeflow.com).
 # Copyright 2025 Kencove (http://www.kencove.com).
 # @author Mohamed Alkobrosli <malkobrosly@kencove.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/website_attribute_set/views/attribute_attribute_view.xml
+++ b/website_attribute_set/views/attribute_attribute_view.xml
@@ -13,9 +13,16 @@
                             <field name="e_com_visibility" />
                         </group>
                         <group invisible="not e_com_visibility">
-                            <field name="e_com_filter" />
+                            <field
+                                name="e_com_filter"
+                                readonly="not field_is_searchable and not e_com_filter"
+                            />
                             <field name="e_com_specification" />
-                            <field name="e_com_searchable" />
+                            <field name="field_is_searchable" invisible="1" />
+                            <field
+                                name="e_com_searchable"
+                                readonly="not field_is_searchable and not e_com_searchable"
+                            />
                             <field
                                 name="e_com_range_filter"
                                 invisible="attribute_type not in ('integer', 'float')"

--- a/website_attribute_set/views/templates.xml
+++ b/website_attribute_set/views/templates.xml
@@ -149,11 +149,11 @@
                     >
                         <input
                             type="checkbox"
-                            name="additional-attribute_value"
+                            name="additional_attribute_values"
                             class="form-check-input"
                             t-att-id="'%s-%s' % (attribute.id, value)"
                             t-att-value="'%s-%s' % (attribute.id, value)"
-                            t-att-checked="(attribute.id, value) in additional_attrib_set"
+                            t-att-checked="(attribute.id, '%s' % value) in additional_attrib_set"
                         />
                         <label
                             class="form-check-label fw-normal"

--- a/website_attribute_set/views/templates.xml
+++ b/website_attribute_set/views/templates.xml
@@ -93,7 +93,7 @@
             <label
                 t-attf-class="btn border {{'active bg-primary-subtle border-primary text-primary-emphasis' if (attribute.id, str(value or '')) in additional_attrib_set else ''}}"
                 t-att-for="'%s-%s' % (attribute.id,value)"
-                t-field="attribute.field_description"
+                t-out="value.display_name if hasattr(value, 'display_name') else value"
             />
         </t>
     </template>
@@ -124,7 +124,7 @@
                     <label
                         class="form-check-label fw-normal"
                         t-att-for="'%s-%s' % (attribute.id, value)"
-                        t-field="attribute.field_description"
+                        t-out="'Yes' if value else 'No'"
                     />
                 </div>
             </div>
@@ -158,7 +158,7 @@
                         <label
                             class="form-check-label fw-normal"
                             t-att-for="'%s-%s' % (attribute.id, value)"
-                            t-field="attribute.field_description"
+                            t-out="'Yes' if value else 'No'"
                         />
                     </div>
                 </t>
@@ -284,7 +284,7 @@
                     <h6 t-else="" class="mb-3">
                         <b
                             class="d-none d-lg-block"
-                            t-field="attribute.field_description"
+                            t-out="attribute.field_description"
                         />
                     </h6>
                     <div
@@ -413,7 +413,7 @@
                     t-attf-aria-controls="o_products_additional_attributes_{{attribute.id}}"
                     t-att-aria-expanded="_expand_attributes"
                 >
-                    <b t-field="attribute.field_description" />
+                    <b t-out="attribute.field_description" />
                 </button>
             </div>
         </xpath>

--- a/website_attribute_set/views/variant_templates.xml
+++ b/website_attribute_set/views/variant_templates.xml
@@ -30,7 +30,7 @@
                             t-attf-class="variant_attribute"
                         >
                             <strong
-                                t-field="attribute.field_description"
+                                t-out="attribute.field_description"
                                 class="attribute_name"
                             />
 


### PR DESCRIPTION
This PR add support for serialized (sparse) custom fields in website_attribute_set: shop filters and search now run direct JSONB queries instead of ORM conditions (which fail for fields not stored in their own SQL column), and several filter bugs are corrected (boolean "No" option never shown, multiselect always empty due to wrong name-...-id-N value parsing, comma-joined multi-values not split, typo in the >10-items template branch). In attribute_set, a constraint is added to block date, datetime, binary, and image attribute types from being marked as serialized, since their convert_to_read returns non-JSON-serializable Python objects and caused a TypeError on save.