### PR TITLE
[19.0][IMP] attribute_set: search attributes by field label

### DIFF
--- a/attribute_set/models/attribute_attribute.py
+++ b/attribute_set/models/attribute_attribute.py
@@ -36,6 +36,10 @@ class AttributeAttribute(models.Model):
     _description = "Attribute"
     _inherits = {"ir.model.fields": "field_id"}
     _order = "sequence_group,sequence,name"
+    # Allow searching attributes both by their technical name and by their
+    # visible label (``field_description``). In a related view (e.g.
+    # attribute.group) the user sees the label rather than the technical name.
+    _rec_names_search = ["name", "field_description"]
 
     field_id = fields.Many2one(
         "ir.model.fields", "Ir Model Fields", required=True, ondelete="cascade"

--- a/attribute_set/tests/__init__.py
+++ b/attribute_set/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_custom_attribute
 from . import test_build_view
 from . import test_native_field_creation
 from . import test_attribute_set_hierarchy
+from . import test_name_search

--- a/attribute_set/tests/test_name_search.py
+++ b/attribute_set/tests/test_name_search.py
@@ -1,0 +1,55 @@
+# Copyright 2025 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from unittest import mock
+
+from odoo.tests import common
+
+
+class TestAttributeNameSearch(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model_id = cls.env.ref("base.model_res_partner").id
+        cls.group = cls.env["attribute.group"].create(
+            {"name": "My Group", "model_id": cls.model_id}
+        )
+        # Do not commit
+        cls.env.cr.commit = mock.Mock()
+        cls.attribute = cls.env["attribute.attribute"].create(
+            {
+                "attribute_type": "char",
+                "nature": "custom",
+                "model_id": cls.model_id,
+                "field_description": "Country of Origin",
+                "name": "x_country_origin",
+                "attribute_group_id": cls.group.id,
+            }
+        )
+
+    def test_name_search_by_technical_name(self):
+        """The attribute is found by its technical name."""
+        results = self.env["attribute.attribute"].name_search("x_country_origin")
+        self.assertIn(self.attribute.id, [r[0] for r in results])
+
+    def test_name_search_by_field_description(self):
+        """The attribute is found by its visible label (field_description)."""
+        results = self.env["attribute.attribute"].name_search("Country of Origin")
+        self.assertIn(self.attribute.id, [r[0] for r in results])
+
+    def test_name_search_partial_field_description(self):
+        """A partial match on the label still finds the attribute."""
+        results = self.env["attribute.attribute"].name_search("Origin")
+        self.assertIn(self.attribute.id, [r[0] for r in results])
+
+    def test_name_search_negative_operator(self):
+        """Negative operators exclude the matching record."""
+        results = self.env["attribute.attribute"].name_search(
+            "Country of Origin", operator="not ilike"
+        )
+        self.assertNotIn(self.attribute.id, [r[0] for r in results])
+
+    def test_name_search_no_match(self):
+        """An unrelated term does not return the attribute."""
+        results = self.env["attribute.attribute"].name_search("does not exist")
+        self.assertNotIn(self.attribute.id, [r[0] for r in results])

--- a/attribute_set/views/attribute_attribute_view.xml
+++ b/attribute_set/views/attribute_attribute_view.xml
@@ -154,6 +154,7 @@
         <field name="model">attribute.attribute</field>
         <field name="arch" type="xml">
             <search string="Search Attributes">
+                <field name="field_description" />
                 <field name="name" />
                 <field name="attribute_group_id" />
             </search>


### PR DESCRIPTION
Override _name_search on attribute.attribute so that selecting an attribute from a related view (e.g. attribute.group) matches both the technical name and the visible field label (field_description). Also expose field_description in the attribute search view and add tests.