### PR TITLE
[19.0][FIX] website_attribute_set: apply numeric range filter to shop listing

### DIFF
--- a/website_attribute_set/controllers/main.py
+++ b/website_attribute_set/controllers/main.py
@@ -12,8 +12,8 @@ from odoo.addons.website_sale.controllers import main
 
 from ..models.mixins import (
     _parse_relational_id,
-    _sparse_filter_by_range,
     _sparse_filter_by_value,
+    build_range_filter_domains,
 )
 
 
@@ -73,6 +73,11 @@ class WebsiteSale(main.WebsiteSale):
         )
         if additional_attrib_list:
             result["additional_attribute_values"] = additional_attrib_list
+        for key in request.httprequest.args.keys():
+            if key.startswith("additional_attr_min_") or key.startswith(
+                "additional_attr_max_"
+            ):
+                result[key] = request.httprequest.args[key]
         return result
 
     def _get_search_options(
@@ -97,6 +102,9 @@ class WebsiteSale(main.WebsiteSale):
         additional_attrib_values = self._parse_additional_attrib_values()
         if additional_attrib_values:
             values["additional_attribute_values"] = additional_attrib_values
+        additional_range_filters = self._parse_additional_range_filters()
+        if additional_range_filters:
+            values["additional_range_filters"] = additional_range_filters
         return values
 
     def _get_additional_shop_values(self, values, **kwargs):
@@ -230,27 +238,7 @@ class WebsiteSale(main.WebsiteSale):
 
     def _build_range_filter_conditions(self, range_filters):
         """Build domain conditions for range filters (min/max)."""
-        conditions = []
-        Attribute = request.env["attribute.attribute"].sudo()
-        for attr_id, range_vals in range_filters.items():
-            attribute = Attribute.browse(attr_id)
-            if not attribute.exists() or not attribute.field_is_searchable:
-                continue
-            field_name = attribute.name
-            field = request.env["product.template"]._fields.get(field_name)
-            sparse_col = getattr(field, "sparse", None) if field else None
-            if sparse_col:
-                ids = _sparse_filter_by_range(
-                    request.env, "product.template", sparse_col, field_name, range_vals
-                )
-                if ids:
-                    conditions.append([("id", "in", ids)])
-                continue
-            if "min" in range_vals:
-                conditions.append([(field_name, ">=", range_vals["min"])])
-            if "max" in range_vals:
-                conditions.append([(field_name, "<=", range_vals["max"])])
-        return conditions
+        return build_range_filter_domains(request.env, range_filters)
 
     def _build_value_filter_conditions(self, attrib_values):
         """Build domain conditions for value filters (select, boolean, etc.)."""

--- a/website_attribute_set/models/mixins.py
+++ b/website_attribute_set/models/mixins.py
@@ -123,6 +123,44 @@ def _sparse_filter_by_range(env, model_name, sparse_col, field_name, range_vals)
     return [row[0] for row in env.cr.fetchall()]
 
 
+def build_range_filter_domains(env, range_filters):
+    """Translate ``{attr_id: {'min': x, 'max': y}}`` into a list of ORM
+    sub-domains over ``product.template``.
+
+    Shared between the shop controller (``_build_range_filter_conditions``)
+    and the website search (``_search_get_details``) so the range filter is
+    applied consistently to the product listing, the price slider and the
+    attribute panel.
+
+    Sparse (serialized) fields have no SQL column to compare against in an ORM
+    domain, so they are resolved to a set of matching IDs via a raw JSONB query.
+    """
+    conditions = []
+    Attribute = env["attribute.attribute"].sudo()
+    pt_fields = env["product.template"]._fields
+    for attr_id, range_vals in range_filters.items():
+        if not range_vals:
+            continue
+        attribute = Attribute.browse(attr_id)
+        if not attribute.exists() or not attribute.field_is_searchable:
+            continue
+        field_name = attribute.name
+        field = pt_fields.get(field_name)
+        sparse_col = getattr(field, "sparse", None) if field else None
+        if sparse_col:
+            ids = _sparse_filter_by_range(
+                env, "product.template", sparse_col, field_name, range_vals
+            )
+            if ids:
+                conditions.append([("id", "in", ids)])
+            continue
+        if "min" in range_vals:
+            conditions.append([(field_name, ">=", range_vals["min"])])
+        if "max" in range_vals:
+            conditions.append([(field_name, "<=", range_vals["max"])])
+    return conditions
+
+
 def search_extra(env, search_term):
     extra_domains = []
     attributes = (

--- a/website_attribute_set/models/mixins.py
+++ b/website_attribute_set/models/mixins.py
@@ -133,7 +133,16 @@ def build_range_filter_domains(env, range_filters):
     attribute panel.
 
     Sparse (serialized) fields have no SQL column to compare against in an ORM
-    domain, so they are resolved to a set of matching IDs via a raw JSONB query.
+    domain, so they are resolved to a set of matching IDs via a raw JSONB query;
+    products that don't carry the attribute simply have no JSON key and are
+    naturally excluded.
+
+    For regular stored fields the attribute's custom column exists on every
+    ``product.template`` and defaults to ``0``, so a bare ``field >= min`` leaf
+    would also match products that don't carry the attribute at all (especially
+    when ``min`` is ``0`` or negative). The ``attribute_set_id`` leaf restricts
+    the filter to the products that actually have the attribute, mirroring the
+    value filter in ``Website._search_get_details``.
     """
     conditions = []
     Attribute = env["attribute.attribute"].sudo()
@@ -151,13 +160,17 @@ def build_range_filter_domains(env, range_filters):
             ids = _sparse_filter_by_range(
                 env, "product.template", sparse_col, field_name, range_vals
             )
-            if ids:
-                conditions.append([("id", "in", ids)])
+            # Always emit the leaf, even when ``ids`` is empty: ``("id", "in",
+            # [])`` correctly matches no product, whereas skipping it would drop
+            # the range constraint and list everything.
+            conditions.append([("id", "in", ids)])
             continue
+        sub_domain = [("attribute_set_id", "in", attribute.attribute_set_ids.ids)]
         if "min" in range_vals:
-            conditions.append([(field_name, ">=", range_vals["min"])])
+            sub_domain.append((field_name, ">=", range_vals["min"]))
         if "max" in range_vals:
-            conditions.append([(field_name, "<=", range_vals["max"])])
+            sub_domain.append((field_name, "<=", range_vals["max"]))
+        conditions.append(sub_domain)
     return conditions
 
 

--- a/website_attribute_set/models/website.py
+++ b/website_attribute_set/models/website.py
@@ -6,7 +6,7 @@ import re
 
 from odoo import api, models
 
-from .mixins import _sparse_filter_by_value
+from .mixins import _sparse_filter_by_value, build_range_filter_domains
 
 
 class Website(models.Model):
@@ -15,9 +15,22 @@ class Website(models.Model):
     @api.model
     def _search_get_details(self, search_type, order, options):
         additional_attrib_values = options.get("additional_attribute_values")
+        additional_range_filters = options.get("additional_range_filters")
         values = super()._search_get_details(
             search_type=search_type, order=order, options=options
         )
+        if additional_range_filters:
+            range_domains = build_range_filter_domains(
+                self.env, additional_range_filters
+            )
+            if range_domains:
+                for value in values:
+                    if value.get("model") != "product.template":
+                        continue
+                    base_domain = value.get("base_domain")
+                    if base_domain is None:
+                        continue
+                    base_domain.extend(range_domains)
         if additional_attrib_values and not isinstance(additional_attrib_values, str):
             for value in values:
                 base_domain = value.get("base_domain")

--- a/website_attribute_set/static/src/interactions/website_sale.esm.js
+++ b/website_attribute_set/static/src/interactions/website_sale.esm.js
@@ -3,82 +3,131 @@ import {patch} from "@web/core/utils/patch";
 import {redirect} from "@web/core/utils/urls";
 import wSaleUtils from "@website_sale/js/website_sale_utils";
 
+// Delay (ms) before applying a numeric range filter. While the user keeps
+// adjusting the value (typing or repeatedly clicking the spinner arrows), each
+// keystroke/click resets the timer so the listing is only reloaded once they
+// stop and the range is fully entered.
+const RANGE_FILTER_DEBOUNCE = 900;
+
+function isRangeFilterInput(el) {
+    return Boolean(
+        el &&
+            el.name &&
+            (el.name.startsWith("additional_attr_min_") ||
+                el.name.startsWith("additional_attr_max_"))
+    );
+}
+
 patch(WebsiteSale.prototype, {
+    setup() {
+        super.setup();
+        // The base interaction only reacts to `change` on the filter inputs.
+        // For the numeric range inputs we also need `input` so that every
+        // keystroke (and spinner click) resets the debounce timer: this lets
+        // the user finish typing/adjusting *both* bounds before we search,
+        // instead of triggering a search as soon as the first bound changes.
+        this.dynamicContent = {
+            ...this.dynamicContent,
+            "form.js_attributes input[type='number']": {
+                "t-on-input": this.onChangeAttribute,
+            },
+        };
+    },
+
     /**
      * @param {Event} ev
      */
     onChangeAttribute(ev) {
-        const productGrid = this.el.querySelector(
-            ".o_wsale_products_grid_table_wrapper"
-        );
-        if (productGrid) {
-            productGrid.classList.add("opacity-50");
-        }
-        const form = wSaleUtils.getClosestProductForm(ev.currentTarget);
-        const filters = form.querySelectorAll("input:checked, select");
-        const rangeInputs = form.querySelectorAll("input[type='number']");
-        const additional_attributeValues = new Map();
-        const attributeValues = new Map();
-        const rangeFilters = new Map();
-        const tags = new Set();
-        for (const filter of filters) {
-            if (filter.value) {
-                if (filter.name === "additional_attribute_values") {
-                    // Group attribute value ids by attribute id.
-                    const firstDash = filter.value.indexOf("-");
-                    const [attributeId, attributeValueId] = [
-                        filter.value.slice(0, firstDash),
-                        filter.value.slice(firstDash + 1),
-                    ];
-                    const valueIds =
-                        additional_attributeValues.get(attributeId) ?? new Set();
-                    valueIds.add(attributeValueId);
-                    additional_attributeValues.set(attributeId, valueIds);
-                } else if (filter.name === "attribute_value") {
-                    // Group attribute value ids by attribute id.
-                    const [attributeId, attributeValueId] = filter.value.split("-");
-                    const valueIds = attributeValues.get(attributeId) ?? new Set();
-                    valueIds.add(attributeValueId);
-                    attributeValues.set(attributeId, valueIds);
-                } else if (filter.name === "tags") {
-                    tags.add(filter.value);
-                } else {
-                    return super.onChangeAttribute(...arguments);
+        const target = ev.currentTarget;
+        // The actual work, kept as an arrow so `super` and `arguments` stay
+        // bound to this method even when called from the debounce timeout.
+        const apply = () => {
+            const productGrid = this.el.querySelector(
+                ".o_wsale_products_grid_table_wrapper"
+            );
+            if (productGrid) {
+                productGrid.classList.add("opacity-50");
+            }
+            const form = wSaleUtils.getClosestProductForm(target);
+            const filters = form.querySelectorAll("input:checked, select");
+            const rangeInputs = form.querySelectorAll("input[type='number']");
+            const additional_attributeValues = new Map();
+            const attributeValues = new Map();
+            const tags = new Set();
+            for (const filter of filters) {
+                if (filter.value) {
+                    if (filter.name === "additional_attribute_values") {
+                        // Group attribute value ids by attribute id.
+                        const firstDash = filter.value.indexOf("-");
+                        const [attributeId, attributeValueId] = [
+                            filter.value.slice(0, firstDash),
+                            filter.value.slice(firstDash + 1),
+                        ];
+                        const valueIds =
+                            additional_attributeValues.get(attributeId) ?? new Set();
+                        valueIds.add(attributeValueId);
+                        additional_attributeValues.set(attributeId, valueIds);
+                    } else if (filter.name === "attribute_value") {
+                        // Group attribute value ids by attribute id.
+                        const [attributeId, attributeValueId] = filter.value.split("-");
+                        const valueIds = attributeValues.get(attributeId) ?? new Set();
+                        valueIds.add(attributeValueId);
+                        attributeValues.set(attributeId, valueIds);
+                    } else if (filter.name === "tags") {
+                        tags.add(filter.value);
+                    } else if (!isRangeFilterInput(filter)) {
+                        return super.onChangeAttribute(...arguments);
+                    }
                 }
             }
-        }
-        // Collect range filter inputs (additional_attr_min_ID / additional_attr_max_ID).
-        for (const input of rangeInputs) {
-            if (input.value) {
-                rangeFilters.set(input.name, input.value);
+            const url = new URL(form.action);
+            const searchParams = url.searchParams;
+            // Aggregate all attribute values belonging to the same attribute into a
+            // single `additional_attribute_values` search param.
+            for (const entry of additional_attributeValues.entries()) {
+                searchParams.append(
+                    "additional_attribute_values",
+                    `${entry[0]}-${[...entry[1]].join(",")}`
+                );
             }
-        }
-        const url = new URL(form.action);
-        const searchParams = url.searchParams;
-        // Aggregate all attribute values belonging to the same attribute into a single
-        // `additional_attribute_values` search param.
-        for (const entry of additional_attributeValues.entries()) {
-            searchParams.append(
-                "additional_attribute_values",
-                `${entry[0]}-${[...entry[1]].join(",")}`
+            // Aggregate all attribute values belonging to the same attribute into a
+            // single `attribute_values` search param.
+            for (const entry of attributeValues.entries()) {
+                searchParams.append(
+                    "attribute_values",
+                    `${entry[0]}-${[...entry[1]].join(",")}`
+                );
+            }
+            // Apply the numeric range filter inputs
+            // (additional_attr_min_ID / additional_attr_max_ID). An empty input
+            // removes the param so the bound is actually cleared instead of
+            // keeping the previously submitted value. Note: `""` is the only
+            // value to treat as empty here -- "0" and negative values are valid
+            // bounds and must be kept.
+            for (const input of rangeInputs) {
+                if (input.value === "") {
+                    searchParams.delete(input.name);
+                } else {
+                    searchParams.set(input.name, input.value);
+                }
+            }
+            // Aggregate all tags into a single `tags` search param.
+            if (tags.size) {
+                searchParams.set("tags", [...tags].join(","));
+            }
+            redirect(`${url.pathname}?${searchParams.toString()}`);
+        };
+        if (isRangeFilterInput(target)) {
+            // Debounce: wait until the user stops adjusting the value before
+            // searching, instead of reloading the listing on every increment or
+            // before the second bound of the range has been entered.
+            clearTimeout(this._rangeFilterTimeout);
+            this._rangeFilterTimeout = this.waitForTimeout(
+                apply,
+                RANGE_FILTER_DEBOUNCE
             );
+            return;
         }
-        // Aggregate all attribute values belonging to the same attribute into a single
-        // `attribute_values` search param.
-        for (const entry of attributeValues.entries()) {
-            searchParams.append(
-                "attribute_values",
-                `${entry[0]}-${[...entry[1]].join(",")}`
-            );
-        }
-        // Append range filter params (additional_attr_min_ID / additional_attr_max_ID).
-        for (const [name, value] of rangeFilters.entries()) {
-            searchParams.set(name, value);
-        }
-        // Aggregate all tags into a single `tags` search param.
-        if (tags.size) {
-            searchParams.set("tags", [...tags].join(","));
-        }
-        redirect(`${url.pathname}?${searchParams.toString()}`);
+        return apply();
     },
 });

--- a/website_attribute_set/tests/__init__.py
+++ b/website_attribute_set/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_website_attr_set
 from . import test_sparse_field_support
 from . import test_controller
 from . import test_shop_ui
+from . import test_range_filter

--- a/website_attribute_set/tests/test_range_filter.py
+++ b/website_attribute_set/tests/test_range_filter.py
@@ -1,0 +1,217 @@
+# Copyright 2026 ForgeFlow (http://www.forgeflow.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpCase, TransactionCase, tagged
+
+from ..models.mixins import build_range_filter_domains
+
+
+class _RangeFilterSetup:
+    @classmethod
+    def _setup_common(cls):
+        cls.website = cls.env.ref("website.default_website")
+        product_model = cls.env.ref("product.model_product_template")
+        cls.attr_group = cls.env["attribute.group"].create(
+            {
+                "name": "Range Group",
+                "model_id": product_model.id,
+                "sequence": 50,
+            }
+        )
+        cls.attr_set = cls.env["attribute.set"].create(
+            {
+                "name": "Range Attribute Set",
+                "model_id": product_model.id,
+            }
+        )
+
+        # Non-sparse integer attribute with the range filter enabled.
+        cls.attr_capacity = cls.env["attribute.attribute"].create(
+            {
+                "nature": "custom",
+                "field_description": "Capacity Liters",
+                "name": "x_range_capacity",
+                "attribute_type": "integer",
+                "attribute_group_id": cls.attr_group.id,
+                "attribute_set_ids": [(4, cls.attr_set.id)],
+                "model_id": product_model.id,
+                "e_com_visibility": True,
+                "e_com_filter": True,
+                "e_com_range_filter": True,
+            }
+        )
+
+        ProductTemplate = cls.env["product.template"]
+        cls.product_in_range = ProductTemplate.create(
+            {
+                "name": "In Range Product",
+                "is_published": True,
+                "website_id": cls.website.id,
+                "attribute_set_id": cls.attr_set.id,
+                "x_range_capacity": 60,
+            }
+        )
+        cls.product_below_range = ProductTemplate.create(
+            {
+                "name": "Below Range Product",
+                "is_published": True,
+                "website_id": cls.website.id,
+                "attribute_set_id": cls.attr_set.id,
+                "x_range_capacity": 5,
+            }
+        )
+        cls.product_above_range = ProductTemplate.create(
+            {
+                "name": "Above Range Product",
+                "is_published": True,
+                "website_id": cls.website.id,
+                "attribute_set_id": cls.attr_set.id,
+                "x_range_capacity": 500,
+            }
+        )
+
+
+class TestBuildRangeFilterDomains(TransactionCase, _RangeFilterSetup):
+    """Unit tests for the shared build_range_filter_domains helper."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_common()
+
+    def test_min_and_max_returns_two_orm_leaves(self):
+        domains = build_range_filter_domains(
+            self.env, {self.attr_capacity.id: {"min": 50, "max": 100}}
+        )
+        self.assertEqual(
+            domains,
+            [
+                [("x_range_capacity", ">=", 50)],
+                [("x_range_capacity", "<=", 100)],
+            ],
+        )
+        matches = self.env["product.template"].search(
+            [("x_range_capacity", ">=", 50), ("x_range_capacity", "<=", 100)]
+        )
+        self.assertIn(self.product_in_range, matches)
+        self.assertNotIn(self.product_below_range, matches)
+        self.assertNotIn(self.product_above_range, matches)
+
+    def test_only_min_or_only_max(self):
+        only_min = build_range_filter_domains(
+            self.env, {self.attr_capacity.id: {"min": 50}}
+        )
+        self.assertEqual(only_min, [[("x_range_capacity", ">=", 50)]])
+        only_max = build_range_filter_domains(
+            self.env, {self.attr_capacity.id: {"max": 100}}
+        )
+        self.assertEqual(only_max, [[("x_range_capacity", "<=", 100)]])
+
+    def test_skips_unknown_attribute(self):
+        domains = build_range_filter_domains(self.env, {99999999: {"min": 0, "max": 1}})
+        self.assertEqual(domains, [])
+
+    def test_skips_empty_range(self):
+        domains = build_range_filter_domains(self.env, {self.attr_capacity.id: {}})
+        self.assertEqual(domains, [])
+
+
+class TestSearchGetDetailsWithRangeFilter(TransactionCase, _RangeFilterSetup):
+    """Ensure the website search domain includes the range filter so the main
+    product listing actually filters by min/max."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_common()
+
+    def _base_options(self, **extra):
+        options = {
+            "displayDescription": False,
+            "displayDetail": False,
+            "displayExtraDetail": False,
+            "displayExtraLink": False,
+            "displayImage": False,
+            "allowFuzzy": False,
+            "category": None,
+            "tags": None,
+            "min_price": 0,
+            "max_price": 0,
+            "attribute_value_dict": None,
+            "display_currency": self.website.currency_id,
+        }
+        options.update(extra)
+        return options
+
+    def test_search_get_details_appends_range_domain(self):
+        options = self._base_options(
+            additional_range_filters={self.attr_capacity.id: {"min": 50, "max": 100}}
+        )
+        details = self.website._search_get_details(
+            "products_only", "name asc, id", options
+        )
+        product_detail = next(
+            d for d in details if d.get("model") == "product.template"
+        )
+        base_domain = product_detail["base_domain"]
+        self.assertIn([("x_range_capacity", ">=", 50)], base_domain)
+        self.assertIn([("x_range_capacity", "<=", 100)], base_domain)
+
+
+@tagged("post_install", "-at_install")
+class TestRangeFilterHttp(HttpCase, _RangeFilterSetup):
+    """End-to-end check via the shop URL."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_common()
+
+    def test_shop_range_filter_excludes_out_of_range_products(self):
+        """Regression: a product whose value is outside the requested
+        [min, max] range must NOT appear in the listing."""
+        self.authenticate("admin", "admin")
+        attr_id = self.attr_capacity.id
+        url = (
+            f"/shop?additional_attr_min_{attr_id}=50&additional_attr_max_{attr_id}=100"
+        )
+        response = self.url_open(url, timeout=30)
+        self.assertEqual(response.status_code, 200)
+        content = response.text
+        self.assertIn(
+            self.product_in_range.name,
+            content,
+            "Product whose value is in the requested range must appear.",
+        )
+        self.assertNotIn(
+            self.product_below_range.name,
+            content,
+            "Product whose value is below the requested range must NOT appear.",
+        )
+        self.assertNotIn(
+            self.product_above_range.name,
+            content,
+            "Product whose value is above the requested range must NOT appear.",
+        )
+
+    def test_range_filter_inputs_preserve_values(self):
+        """Regression: the min/max inputs must show the value the user
+        submitted, not appear empty after the redirect."""
+        self.authenticate("admin", "admin")
+        attr_id = self.attr_capacity.id
+        url = (
+            f"/shop?additional_attr_min_{attr_id}=50&additional_attr_max_{attr_id}=100"
+        )
+        response = self.url_open(url, timeout=30)
+        self.assertEqual(response.status_code, 200)
+        content = response.text
+        self.assertIn(f'name="additional_attr_min_{attr_id}"', content)
+        self.assertIn(f'name="additional_attr_max_{attr_id}"', content)
+        self.assertRegex(
+            content,
+            rf'name="additional_attr_min_{attr_id}"[^>]*value="50"',
+        )
+        self.assertRegex(
+            content,
+            rf'name="additional_attr_max_{attr_id}"[^>]*value="100"',
+        )

--- a/website_attribute_set/tests/test_range_filter.py
+++ b/website_attribute_set/tests/test_range_filter.py
@@ -69,6 +69,16 @@ class _RangeFilterSetup:
                 "x_range_capacity": 500,
             }
         )
+        # Product without the attribute set: it does NOT carry the attribute,
+        # but x_range_capacity is a real column defaulting to 0, so a
+        # ``>= 0``/negative filter must NOT pick it up.
+        cls.product_no_attr_set = ProductTemplate.create(
+            {
+                "name": "No Attribute Set Product",
+                "is_published": True,
+                "website_id": cls.website.id,
+            }
+        )
 
 
 class TestBuildRangeFilterDomains(TransactionCase, _RangeFilterSetup):
@@ -79,33 +89,53 @@ class TestBuildRangeFilterDomains(TransactionCase, _RangeFilterSetup):
         super().setUpClass()
         cls._setup_common()
 
-    def test_min_and_max_returns_two_orm_leaves(self):
+    def test_min_and_max_returns_one_combined_sub_domain(self):
+        set_ids = self.attr_capacity.attribute_set_ids.ids
         domains = build_range_filter_domains(
             self.env, {self.attr_capacity.id: {"min": 50, "max": 100}}
         )
         self.assertEqual(
             domains,
             [
-                [("x_range_capacity", ">=", 50)],
-                [("x_range_capacity", "<=", 100)],
+                [
+                    ("attribute_set_id", "in", set_ids),
+                    ("x_range_capacity", ">=", 50),
+                    ("x_range_capacity", "<=", 100),
+                ],
             ],
         )
-        matches = self.env["product.template"].search(
-            [("x_range_capacity", ">=", 50), ("x_range_capacity", "<=", 100)]
-        )
+        matches = self.env["product.template"].search(domains[0])
         self.assertIn(self.product_in_range, matches)
         self.assertNotIn(self.product_below_range, matches)
         self.assertNotIn(self.product_above_range, matches)
 
+    def test_zero_min_excludes_products_without_the_attribute(self):
+        """Regression: a ``>= 0`` (or negative) bound must not match products
+        that don't carry the attribute just because the column defaults to 0."""
+        domains = build_range_filter_domains(
+            self.env, {self.attr_capacity.id: {"min": 0}}
+        )
+        matches = self.env["product.template"].search(domains[0])
+        self.assertIn(self.product_in_range, matches)
+        self.assertIn(self.product_below_range, matches)
+        self.assertNotIn(self.product_no_attr_set, matches)
+
     def test_only_min_or_only_max(self):
+        set_ids = self.attr_capacity.attribute_set_ids.ids
         only_min = build_range_filter_domains(
             self.env, {self.attr_capacity.id: {"min": 50}}
         )
-        self.assertEqual(only_min, [[("x_range_capacity", ">=", 50)]])
+        self.assertEqual(
+            only_min,
+            [[("attribute_set_id", "in", set_ids), ("x_range_capacity", ">=", 50)]],
+        )
         only_max = build_range_filter_domains(
             self.env, {self.attr_capacity.id: {"max": 100}}
         )
-        self.assertEqual(only_max, [[("x_range_capacity", "<=", 100)]])
+        self.assertEqual(
+            only_max,
+            [[("attribute_set_id", "in", set_ids), ("x_range_capacity", "<=", 100)]],
+        )
 
     def test_skips_unknown_attribute(self):
         domains = build_range_filter_domains(self.env, {99999999: {"min": 0, "max": 1}})
@@ -114,6 +144,106 @@ class TestBuildRangeFilterDomains(TransactionCase, _RangeFilterSetup):
     def test_skips_empty_range(self):
         domains = build_range_filter_domains(self.env, {self.attr_capacity.id: {}})
         self.assertEqual(domains, [])
+
+
+class TestSparseRangeFilterDomains(TransactionCase):
+    """build_range_filter_domains on a serialized (sparse) numeric attribute.
+
+    Sparse fields have no SQL column, so the range is resolved to a set of
+    matching IDs via a raw JSONB query. The comparison is numeric, products
+    without the attribute are excluded, and an empty result still filters to
+    zero (it must never fall back to listing everything).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        product_model = cls.env.ref("product.model_product_template")
+        cls.attr_group = cls.env["attribute.group"].create(
+            {
+                "name": "Sparse Range Group",
+                "model_id": product_model.id,
+                "sequence": 60,
+            }
+        )
+        cls.attr_set = cls.env["attribute.set"].create(
+            {
+                "name": "Sparse Range Attribute Set",
+                "model_id": product_model.id,
+            }
+        )
+        # serialized=True makes x_sparse_capacity a sparse field backed by the
+        # shared x_custom_json_attrs JSON column.
+        cls.attr_capacity = cls.env["attribute.attribute"].create(
+            {
+                "nature": "custom",
+                "field_description": "Sparse Capacity",
+                "name": "x_sparse_capacity",
+                "attribute_type": "integer",
+                "attribute_group_id": cls.attr_group.id,
+                "attribute_set_ids": [(4, cls.attr_set.id)],
+                "model_id": product_model.id,
+                "e_com_visibility": True,
+                "e_com_filter": True,
+                "e_com_range_filter": True,
+                "serialized": True,
+            }
+        )
+        ProductTemplate = cls.env["product.template"]
+        cls.product_in_range = ProductTemplate.create(
+            {
+                "name": "Sparse In Range",
+                "attribute_set_id": cls.attr_set.id,
+                "x_sparse_capacity": 60,
+            }
+        )
+        cls.product_out_range = ProductTemplate.create(
+            {
+                "name": "Sparse Out Range",
+                "attribute_set_id": cls.attr_set.id,
+                "x_sparse_capacity": 5,
+            }
+        )
+        cls.product_no_attr_set = ProductTemplate.create(
+            {"name": "Sparse No Attribute Set"}
+        )
+        # The range filter reads the JSON column with raw SQL, so the pending
+        # values must be flushed to the database first.
+        cls.env.flush_all()
+
+    def test_field_is_sparse(self):
+        field = self.env["product.template"]._fields["x_sparse_capacity"]
+        self.assertTrue(getattr(field, "sparse", None))
+
+    def test_range_resolves_to_id_in_with_numeric_comparison(self):
+        domains = build_range_filter_domains(
+            self.env, {self.attr_capacity.id: {"min": 50, "max": 100}}
+        )
+        self.assertEqual(len(domains), 1)
+        leaf = domains[0][0]
+        self.assertEqual((leaf[0], leaf[1]), ("id", "in"))
+        ids = leaf[2]
+        self.assertIn(self.product_in_range.id, ids)
+        self.assertNotIn(self.product_out_range.id, ids)
+        self.assertNotIn(self.product_no_attr_set.id, ids)
+
+    def test_zero_min_excludes_products_without_the_attribute(self):
+        domains = build_range_filter_domains(
+            self.env, {self.attr_capacity.id: {"min": 0}}
+        )
+        ids = domains[0][0][2]
+        self.assertIn(self.product_in_range.id, ids)
+        self.assertIn(self.product_out_range.id, ids)
+        self.assertNotIn(self.product_no_attr_set.id, ids)
+
+    def test_empty_result_filters_to_zero(self):
+        """Regression: a range that matches no product must emit ``id in []``
+        (which selects nothing) instead of dropping the constraint."""
+        domains = build_range_filter_domains(
+            self.env, {self.attr_capacity.id: {"min": 9000}}
+        )
+        self.assertEqual(domains, [[("id", "in", [])]])
+        self.assertFalse(self.env["product.template"].search(domains[0]))
 
 
 class TestSearchGetDetailsWithRangeFilter(TransactionCase, _RangeFilterSetup):
@@ -154,8 +284,15 @@ class TestSearchGetDetailsWithRangeFilter(TransactionCase, _RangeFilterSetup):
             d for d in details if d.get("model") == "product.template"
         )
         base_domain = product_detail["base_domain"]
-        self.assertIn([("x_range_capacity", ">=", 50)], base_domain)
-        self.assertIn([("x_range_capacity", "<=", 100)], base_domain)
+        set_ids = self.attr_capacity.attribute_set_ids.ids
+        self.assertIn(
+            [
+                ("attribute_set_id", "in", set_ids),
+                ("x_range_capacity", ">=", 50),
+                ("x_range_capacity", "<=", 100),
+            ],
+            base_domain,
+        )
 
 
 @tagged("post_install", "-at_install")
@@ -192,6 +329,26 @@ class TestRangeFilterHttp(HttpCase, _RangeFilterSetup):
             self.product_above_range.name,
             content,
             "Product whose value is above the requested range must NOT appear.",
+        )
+
+    def test_shop_zero_min_excludes_products_without_attribute(self):
+        """Regression: filtering with min=0 must not list products that don't
+        carry the attribute (their column defaults to 0)."""
+        self.authenticate("admin", "admin")
+        attr_id = self.attr_capacity.id
+        url = f"/shop?additional_attr_min_{attr_id}=0"
+        response = self.url_open(url, timeout=30)
+        self.assertEqual(response.status_code, 200)
+        content = response.text
+        self.assertIn(
+            self.product_in_range.name,
+            content,
+            "Product carrying the attribute must appear with a min=0 filter.",
+        )
+        self.assertNotIn(
+            self.product_no_attr_set.name,
+            content,
+            "Product without the attribute must NOT appear with a min=0 filter.",
         )
 
     def test_range_filter_inputs_preserve_values(self):

--- a/website_attribute_set/views/templates.xml
+++ b/website_attribute_set/views/templates.xml
@@ -68,6 +68,7 @@
                 t-attf-name="additional_attr_min_{{attribute.id}}"
                 placeholder="Min"
                 t-att-step="'1' if attribute.attribute_type == 'integer' else '0.01'"
+                t-att-value="request.params.get('additional_attr_min_%s' % attribute.id) or ''"
             />
             <input
                 type="number"
@@ -75,6 +76,7 @@
                 t-attf-name="additional_attr_max_{{attribute.id}}"
                 placeholder="Max"
                 t-att-step="'1' if attribute.attribute_type == 'integer' else '0.01'"
+                t-att-value="request.params.get('additional_attr_max_%s' % attribute.id) or ''"
             />
         </div>
     </template>

--- a/website_attribute_set/views/templates.xml
+++ b/website_attribute_set/views/templates.xml
@@ -68,7 +68,7 @@
                 t-attf-name="additional_attr_min_{{attribute.id}}"
                 placeholder="Min"
                 t-att-step="'1' if attribute.attribute_type == 'integer' else '0.01'"
-                t-att-value="request.params.get('additional_attr_min_%s' % attribute.id) or ''"
+                t-att-value="request.params.get('additional_attr_min_%s' % attribute.id, '')"
             />
             <input
                 type="number"
@@ -76,7 +76,7 @@
                 t-attf-name="additional_attr_max_{{attribute.id}}"
                 placeholder="Max"
                 t-att-step="'1' if attribute.attribute_type == 'integer' else '0.01'"
-                t-att-value="request.params.get('additional_attr_max_%s' % attribute.id) or ''"
+                t-att-value="request.params.get('additional_attr_max_%s' % attribute.id, '')"
             />
         </div>
     </template>


### PR DESCRIPTION
The min/max numeric range filter (additional_attr_min_X / additional_attr_max_X) was parsed by the controller but never reached the website search domain, so products outside the requested range were still listed. The min/max inputs also lost their value after submit because the template had no value binding.

- Add a shared build_range_filter_domains helper in mixins.py.
- Pass additional_range_filters through _get_search_options so they reach Website._search_get_details, which now extends each product.template base_domain with the range leaves.
- Propagate the range params in _shop_get_query_url_kwargs so they survive pagination/sort.
- Bind request.params back to the min/max inputs in filter_range_attributes so the values persist across submissions.
- Add tests covering the helper, the search-detail integration and the full shop URL.