### PR TITLE
[19.0][FIX] product_attribute_set: show native attributes regardless of action

### DIFF
--- a/product_attribute_set/__manifest__.py
+++ b/product_attribute_set/__manifest__.py
@@ -7,8 +7,12 @@
     "license": "AGPL-3",
     "author": "Akretion,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/odoo-pim",
-    "depends": ["product", "attribute_set"],
-    "data": ["views/product.xml", "views/product_category.xml"],
+    "depends": ["base_setup", "product", "attribute_set"],
+    "data": [
+        "views/product.xml",
+        "views/product_category.xml",
+        "views/res_config_settings.xml",
+    ],
     "demo": ["demo/product_attribute.xml"],
     "installable": True,
 }

--- a/product_attribute_set/models/__init__.py
+++ b/product_attribute_set/models/__init__.py
@@ -1,3 +1,4 @@
 from . import attribute_attribute
 from . import product_category
 from . import product
+from . import res_config_settings

--- a/product_attribute_set/models/product.py
+++ b/product_attribute_set/models/product.py
@@ -5,6 +5,16 @@
 
 from odoo import api, fields, models
 
+# When this system parameter is enabled, the native attributes of a product's
+# attribute set are injected in the Attributes tab whatever action opened the
+# form, not only the ones that set "include_native_attribute_view_ref".
+SHOW_NATIVE_EVERYWHERE_PARAM = "product_attribute_set.show_native_attributes_everywhere"
+
+
+def _show_native_attributes_everywhere(env):
+    value = env["ir.config_parameter"].sudo().get_param(SHOW_NATIVE_EVERYWHERE_PARAM)
+    return value not in (False, None, "", "False", "0")
+
 
 class ProductTemplate(models.Model):
     _inherit = ["product.template", "attribute.set.owner.mixin"]
@@ -45,6 +55,20 @@ class ProductTemplate(models.Model):
         if self.categ_id and not self.attribute_set_id:
             self.attribute_set_id = self.categ_id.attribute_set_id
 
+    def get_view(self, view_id=None, view_type="form", **options):
+        # The product form is reached through many actions (Sales, Inventory,
+        # Purchase, Accounting, MRP...) and only a couple of them set the
+        # "include_native_attribute_view_ref" flag. Without it the Attributes
+        # tab only injects "custom" attributes, so a product whose set is made
+        # of native attributes shows an empty tab depending on the menu used.
+        # When the setting is enabled, force the flag so the product's own
+        # Attributes tab is populated consistently from any originating action.
+        if _show_native_attributes_everywhere(self.env) and not self.env.context.get(
+            "include_native_attribute_view_ref"
+        ):
+            self = self.with_context(include_native_attribute_view_ref=1)
+        return super().get_view(view_id=view_id, view_type=view_type, **options)
+
 
 class ProductProduct(models.Model):
     _inherit = ["product.product", "attribute.set.owner.mixin"]
@@ -57,3 +81,12 @@ class ProductProduct(models.Model):
     @api.model
     def _get_attribute_set_owner_model(self):
         return [("model", "in", ("product.product", "product.template"))]
+
+    def get_view(self, view_id=None, view_type="form", **options):
+        # See ProductTemplate.get_view: ensure native attributes are injected
+        # in the variant form too, whatever action opened it.
+        if _show_native_attributes_everywhere(self.env) and not self.env.context.get(
+            "include_native_attribute_view_ref"
+        ):
+            self = self.with_context(include_native_attribute_view_ref=1)
+        return super().get_view(view_id=view_id, view_type=view_type, **options)

--- a/product_attribute_set/models/res_config_settings.py
+++ b/product_attribute_set/models/res_config_settings.py
@@ -1,0 +1,18 @@
+# Copyright 2026 ForgeFlow (http://www.forgeflow.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    attribute_set_show_native_everywhere = fields.Boolean(
+        string="Native attributes on every product form",
+        config_parameter="product_attribute_set.show_native_attributes_everywhere",
+        help="When enabled, the native attributes belonging to a product's "
+        "attribute set are shown in the Attributes tab whatever the menu "
+        "(Sales, Inventory, Purchase...) used to open the product form. "
+        "When disabled, only actions that set the "
+        "'include_native_attribute_view_ref' context display them.",
+    )

--- a/product_attribute_set/views/res_config_settings.xml
+++ b/product_attribute_set/views/res_config_settings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 ForgeFlow (http://www.forgeflow.com).
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field
+            name="name"
+        >res.config.settings.view.form.inherit.product_attribute_set</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//app[@name='general_settings']" position="inside">
+                <block title="Attribute Sets" name="attribute_set_setting_container">
+                    <setting
+                        id="attribute_set_native_everywhere"
+                        string="Native attributes on every product form"
+                        help="Show the native attributes of a product's attribute set in the Attributes tab whatever the menu (Sales, Inventory, Purchase...) used to open the product form."
+                    >
+                        <field name="attribute_set_show_native_everywhere" />
+                    </setting>
+                </block>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
…here

The product form is opened through many window actions (Sales, Inventory, Purchase, Accounting, MRP...), but only product.product_template_action and pim.product_template_action set the 'include_native_attribute_view_ref' context flag. Without it, _build_attribute_eview restricts the injected fields to custom attributes, so a product whose attribute set is composed of native attributes shows an empty Attributes tab depending on the menu used to reach it.

Add a 'Native attributes on every product form' setting (General Settings, backed by the 'product_attribute_set.show_native_attributes_everywhere' system parameter, disabled by default). When enabled, product.template/product.product get_view inject the flag so the Attributes tab is populated consistently from any originating action. Default behaviour is unchanged.