### PR TITLE
[19.0][FIX] website_attribute_set: filter toggling, scoping and boolean search

### DIFF
--- a/website_attribute_set/controllers/main.py
+++ b/website_attribute_set/controllers/main.py
@@ -261,6 +261,7 @@ class WebsiteSale(main.WebsiteSale):
             attr_type = attribute.attribute_type
             field = request.env["product.template"]._fields.get(field_name)
             sparse_col = getattr(field, "sparse", None) if field else None
+            attr_conditions = []
             if sparse_col:
                 if len(values) > 1 and attribute.e_com_multi_select:
                     all_ids = []
@@ -276,7 +277,7 @@ class WebsiteSale(main.WebsiteSale):
                             )
                         )
                     if all_ids:
-                        conditions.append([("id", "in", list(set(all_ids)))])
+                        attr_conditions.append([("id", "in", list(set(all_ids)))])
                 else:
                     for attr_value in values:
                         ids = _sparse_filter_by_value(
@@ -288,24 +289,31 @@ class WebsiteSale(main.WebsiteSale):
                             attr_value,
                         )
                         if ids:
-                            conditions.append([("id", "in", ids)])
-                continue
-
-            if len(values) > 1 and attribute.e_com_multi_select:
+                            attr_conditions.append([("id", "in", ids)])
+            elif len(values) > 1 and attribute.e_com_multi_select:
                 or_conds = [
                     c
                     for v in values
                     if (c := self._build_attribute_condition(field_name, attr_type, v))
                 ]
                 if or_conds:
-                    conditions.append(Domain.OR(or_conds))
+                    attr_conditions.append(Domain.OR(or_conds))
             else:
                 for attr_value in values:
                     cond = self._build_attribute_condition(
                         field_name, attr_type, attr_value
                     )
                     if cond:
-                        conditions.append(cond)
+                        attr_conditions.append(cond)
+            if attr_conditions:
+                conditions.extend(attr_conditions)
+                # The underlying field exists on every product.template
+                # (native attributes are real fields), so scope the filter to
+                # the products whose attribute set actually carries this
+                # attribute — the same products the facet is rendered for.
+                conditions.append(
+                    [("attribute_set_id", "in", attribute.attribute_set_ids.ids)]
+                )
         return conditions
 
     def _build_attribute_condition(self, field_name, attr_type, attr_value):

--- a/website_attribute_set/models/website.py
+++ b/website_attribute_set/models/website.py
@@ -85,6 +85,13 @@ class Website(models.Model):
                             ]
                             base_domain.append(additional_attrib_domain)
                     else:
+                        if attribute_field.attribute_type == "boolean":
+                            # The URL param carries the value as a string:
+                            # convert it like the shop controller does, so
+                            # that "False" does not end up truthy.
+                            additional_attrib_value = (
+                                additional_attrib_value.lower() == "true"
+                            )
                         additional_attrib_domain = [
                             (attribute_name, "=", additional_attrib_value)
                         ]

--- a/website_attribute_set/models/website.py
+++ b/website_attribute_set/models/website.py
@@ -60,7 +60,16 @@ class Website(models.Model):
                             additional_attrib_value,
                         )
                         if ids:
-                            base_domain.append([("id", "in", ids)])
+                            base_domain.append(
+                                [
+                                    ("id", "in", ids),
+                                    (
+                                        "attribute_set_id",
+                                        "in",
+                                        attribute_field.attribute_set_ids.ids,
+                                    ),
+                                ]
+                            )
                         continue
 
                     if attribute_field.attribute_type in (
@@ -93,7 +102,12 @@ class Website(models.Model):
                                 additional_attrib_value.lower() == "true"
                             )
                         additional_attrib_domain = [
-                            (attribute_name, "=", additional_attrib_value)
+                            (attribute_name, "=", additional_attrib_value),
+                            (
+                                "attribute_set_id",
+                                "in",
+                                attribute_field.attribute_set_ids.ids,
+                            ),
                         ]
                         base_domain.append(additional_attrib_domain)
         return values

--- a/website_attribute_set/views/templates.xml
+++ b/website_attribute_set/views/templates.xml
@@ -236,6 +236,14 @@
         inherit_id="website_sale.product_attribute_filters_form"
         name="Product Attribute Filters Form"
     >
+        <!-- Exclude additional_attribute_values from the form action: the JS
+             handler rebuilds it from the checked inputs, so a stale value kept
+             by keep() would make unchecking a filter impossible. -->
+        <xpath expr="//form" position="attributes">
+            <attribute
+                name="t-att-action"
+            >keep(attribute_values=0, tags=0, additional_attribute_values=0)</attribute>
+        </xpath>
         <xpath expr="//form" position="inside">
             <t
                 t-set="additional_filter_attributes"


### PR DESCRIPTION
- Exclude additional_attribute_values from the filter form action so unchecking a filter actually clears it.
- Convert boolean values from the URL in the search path so "False" is not treated as truthy.
- Scope value filters to products whose attribute set carries the attribute, consistently across the shop grid and website search.