### PR TITLE
[19.0][FIX] attribute_set: sudo delegated ir.model.fields read

### DIFF
--- a/attribute_set/models/attribute_set_owner.py
+++ b/attribute_set/models/attribute_set_owner.py
@@ -41,12 +41,16 @@ class AttributeSetOwnerMixin(models.AbstractModel):
     @api.model
     def remove_native_fields(self, eview):
         """Remove native fields related to native attributes from eview"""
-        native_attrs = self.env["attribute.attribute"].search(
-            [
-                ("model", "=", self._name),
-                ("attribute_set_ids", "!=", False),
-                ("nature", "=", "native"),
-            ]
+        native_attrs = (
+            self.env["attribute.attribute"]
+            .sudo()
+            .search(
+                [
+                    ("model", "=", self._name),
+                    ("attribute_set_ids", "!=", False),
+                    ("nature", "=", "native"),
+                ]
+            )
         )
         for attr in native_attrs:
             for efield in eview.xpath(f"//field[@name='{attr.name}']"):

--- a/attribute_set/tests/test_build_view.py
+++ b/attribute_set/tests/test_build_view.py
@@ -307,6 +307,26 @@ class BuildViewCase(TransactionCase):
             )
         )
 
+    @users("demo")
+    def test_remove_native_fields_as_plain_user(self):
+        """A user without "Access Rights" must be able to strip native fields.
+
+        ``attribute.attribute`` delegates ``name`` to ``ir.model.fields``, and
+        regular users have no read access on that model, so the attributes must
+        be looked up in sudo.
+
+        The method is called directly, and the record cache emptied first,
+        because going through ``get_views()`` cannot catch the regression:
+        ``_get_view_fields()`` reads the same names in sudo beforehand, leaving
+        them in the record cache, so the un-sudoed read never reaches the
+        database and no access check happens.
+        """
+        native_field_name = self.attr_native.sudo().name
+        eview = etree.fromstring(f"<form><field name='{native_field_name}'/></form>")
+        self.env.invalidate_all()
+        self.env["res.partner"].remove_native_fields(eview)
+        self.assertFalse(eview.xpath(f"//field[@name='{native_field_name}']"))
+
     # TESTS UNLINK
     def test_unlink_custom_attribute(self):
         attr_1_field_id = self.attr_1.field_id.id


### PR DESCRIPTION
'attribute.attribute' delegates 'name' to 'ir.model.fields', a model 'base.group_user' has had no read access on since 16.0. 'remove_native_fields()' searched the native attributes as the current user and then read 'attr.name', so any user without read rights got:

    You are not allowed to access 'Fields' (ir.model.fields) records.

This completes commit e88325c ('[FIX] avoid ir.model accessError'), which fixed the search domains of the three attribute lookups and added the 'sudo()' to the 'mapped(name) of _get_view_fields(), but left the 'attr.name' read of this loop untouched.