### PR TITLE
[19.0][FIX] pim: grant PIM roles the access rights their descriptions promise

### DIFF
--- a/pim/__manifest__.py
+++ b/pim/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Product Information Management",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "license": "AGPL-3",
     "author": "Akretion,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/odoo-pim",
@@ -14,6 +14,7 @@
     "data": [
         "data/ir_module_category_data.xml",
         "security/pim_security.xml",
+        "security/ir.model.access.csv",
         "views/product_view.xml",
         "views/pim_view.xml",
         "views/attribute_set.xml",

--- a/pim/readme/HISTORY.md
+++ b/pim/readme/HISTORY.md
@@ -1,0 +1,8 @@
+## 19.0.1.1.0 (2026-08-06)
+
+- Grant the PIM roles the access rights their descriptions promise. **PIM
+  Manager** can now create/edit attribute sets, groups, attributes and options
+  (previously only `base.group_erp_manager` could, so a PIM Manager saw the menus
+  but hit AccessError on create/write -- the role was non-functional without the
+  admin group), and **PIM User** can edit products. Adds the missing
+  `ir.model.access.csv`.

--- a/pim/security/ir.model.access.csv
+++ b/pim/security/ir.model.access.csv
@@ -1,0 +1,7 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_pim_attribute_set_manager,attribute.set pim manager,attribute_set.model_attribute_set,pim.group_pim_manager,1,1,1,1
+access_pim_attribute_group_manager,attribute.group pim manager,attribute_set.model_attribute_group,pim.group_pim_manager,1,1,1,1
+access_pim_attribute_attribute_manager,attribute.attribute pim manager,attribute_set.model_attribute_attribute,pim.group_pim_manager,1,1,1,1
+access_pim_attribute_option_manager,attribute.option pim manager,attribute_set.model_attribute_option,pim.group_pim_manager,1,1,1,1
+access_pim_product_template_user,product.template pim user,product.model_product_template,pim.group_pim_user,1,1,0,0
+access_pim_product_product_user,product.product pim user,product.model_product_product,pim.group_pim_user,1,1,0,0

--- a/pim/tests/__init__.py
+++ b/pim/tests/__init__.py
@@ -1,0 +1,2 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import test_pim_access

--- a/pim/tests/test_pim_access.py
+++ b/pim/tests/test_pim_access.py
@@ -1,0 +1,52 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.exceptions import AccessError
+from odoo.tests.common import TransactionCase, new_test_user
+
+
+class TestPimAccess(TransactionCase):
+    """A PIM Manager must be able to manage attribute sets without the
+    Settings / ERP Manager admin group, and a PIM Reader must not."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model_product = cls.env.ref("product.model_product_template")
+        cls.manager = new_test_user(
+            cls.env,
+            login="pim_manager",
+            groups="base.group_user,pim.group_pim_manager",
+        )
+        cls.reader = new_test_user(
+            cls.env,
+            login="pim_reader",
+            groups="base.group_user,pim.group_pim_reader",
+        )
+
+    def test_manager_is_not_admin(self):
+        # The whole point: management without the admin (ERP Manager) group.
+        self.assertFalse(self.manager.has_group("base.group_erp_manager"))
+
+    def test_manager_can_create_attribute_set(self):
+        attr_set = (
+            self.env["attribute.set"]
+            .with_user(self.manager)
+            .create({"name": "PIM set", "model_id": self.model_product.id})
+        )
+        self.assertTrue(attr_set.id)
+        # and edit / delete it
+        attr_set.write({"name": "PIM set renamed"})
+        attr_set.unlink()
+
+    def test_manager_can_create_attribute_group(self):
+        group = (
+            self.env["attribute.group"]
+            .with_user(self.manager)
+            .create({"name": "PIM group", "model_id": self.model_product.id})
+        )
+        self.assertTrue(group.id)
+
+    def test_reader_cannot_create_attribute_set(self):
+        with self.assertRaises(AccessError):
+            self.env["attribute.set"].with_user(self.reader).create(
+                {"name": "Nope", "model_id": self.model_product.id}
+            )


### PR DESCRIPTION
## The problem

The `pim` module ships three group definitions — **PIM Reader**, **PIM User**,
**PIM Manager** — and advertises (group description) that the Manager *"will be
able to modify products and create attributes"*. It also adds a **PIM** app with
an **Attributes** menu pointing at `attribute.set`.

But `pim` ships **no `ir.model.access.csv`**, and `attribute_set` grants
write/create on its models only to `base.group_erp_manager`. So a user who has
**only** PIM Manager (a deliberately non-admin PIM operator, no Settings / no
developer mode) can open the PIM app and *read* attribute sets, but hits
`AccessError` the moment they create or edit one. The three roles are
non-functional without also handing the user the ERP-admin group — which defeats
the point of having them.

## The fix

Add `pim/security/ir.model.access.csv`:

- **PIM Manager** → full CRUD on `attribute.set`, `attribute.group`,
  `attribute.attribute`, `attribute.option`.
- **PIM User** → write on `product.template` / `product.product`.

(Read access to these models for internal users already comes from
`attribute_set` / `product`.)

Bumps `19.0.1.0.0` → `19.0.1.1.0`.

## Tests

Adds `pim/tests/test_pim_access.py` proving, with a user that is **not** an ERP
Manager:

- a PIM Manager can create / rename / delete an `attribute.set` and create an
  `attribute.group`;
- a PIM Reader **cannot** create an `attribute.set`.

## Note / scope

Creating an individual `attribute.attribute` additionally requires
`attribute_set` to run the backing `ir.model.fields` read **and create** under
sudo — the read side is #265. This PR covers the attribute-**set** access layer
(sets, groups, options, and the product write for PIM User); a complementary
`attribute_set` change is needed for full per-attribute creation by a non-admin.