### PR TITLE
[19.0][FIX] pim: hide variant menus when variants are disabled

### DIFF
--- a/pim/views/pim_view.xml
+++ b/pim/views/pim_view.xml
@@ -26,6 +26,7 @@
         name="Variants Attributes"
         parent="root_menu_pim"
         sequence="10"
+        groups="product.group_product_variant"
     />
     <menuitem
         id="main_menu_category"
@@ -48,6 +49,7 @@
         action="product.product_normal_action_sell"
         parent="main_menu_product"
         sequence="1"
+        groups="product.group_product_variant"
     />
     <!-- Menu Attributes -->
     <menuitem
@@ -56,6 +58,7 @@
         action="product.attribute_action"
         parent="main_menu_variant_attribute"
         sequence="0"
+        groups="product.group_product_variant"
     />
     <menuitem
         id="menu_variant_attribute_value"
@@ -63,5 +66,6 @@
         action="pim.product_attribute_value_action"
         parent="main_menu_variant_attribute"
         sequence="1"
+        groups="product.group_product_variant"
     />
 </odoo>


### PR DESCRIPTION
## Problem
The PIM app always shows the **Product Variants** menu (`menu_product_product`) and the whole **Variants Attributes** section (`main_menu_variant_attribute` + children), even on databases where product variants are turned off.

Native Odoo gates the equivalent menus behind `product.group_product_variant` (see `sale/views/sale_menus.xml`):
```xml
<menuitem action="product.product_normal_action_sell" groups="product.group_product_variant"/>
<menuitem action="product.attribute_action" groups="product.group_product_variant"/>
```
So when the *Variants* feature is disabled, native Odoo hides them — but the PIM re-declares the same actions as menuitems without the group, so they stay visible.

## Fix
Add `groups="product.group_product_variant"` to the pim variant menus (`menu_product_product`, `main_menu_variant_attribute`, `menu_variant_attribute`, `menu_variant_attribute_value`), mirroring native behaviour.

This is especially relevant for PIM deployments that use `attribute_set` instead of native product variants, where these menus are never applicable.

## Behaviour
- Variants enabled → menus visible (unchanged).
- Variants disabled → menus hidden (matches native Odoo).